### PR TITLE
Fix Installation of Nvidia Container Toolkit in `dev_setup.sh`

### DIFF
--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -44,7 +44,7 @@ is_nvidia_container_toolkit_installed() {
 if ! is_nvidia_container_toolkit_installed; then
     echo -e "\033[1;32mNVIDIA Container Toolkit is not installed. Installing...\033[0m"
 	if (($(nvidia-smi -L | wc -l) > 0)); then
-		curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg -y && \
+		curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg \
 			curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | \
 			sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
 			sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list

--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -45,7 +45,7 @@ if ! is_nvidia_container_toolkit_installed; then
     echo -e "\033[1;32mNVIDIA Container Toolkit is not installed. Installing...\033[0m"
 	if (($(nvidia-smi -L | wc -l) > 0)); then
 		curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg \
-			curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | \
+		&& curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | \
 			sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
 			sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
 		sudo apt-get update


### PR DESCRIPTION
Attempted the install with `dev_setup.sh` on my laptop (fresh Ubuntu 22 install), and got errors with the Nvidia Container Toolkit install. Looks like these lines were different from the original Nvidia docs. When I ran these it seemed to work. Updated the setup file to reflect this.