### PR TITLE
Refactor callback exposure

### DIFF
--- a/obelisk/python/obelisk_py/control.py
+++ b/obelisk/python/obelisk_py/control.py
@@ -54,9 +54,9 @@ class ObeliskController(ABC, ObeliskNode):
         self.sub_est_config_str = self.get_parameter("sub_est_config_str").get_parameter_value().string_value
 
         # create publishers+timers/subscribers
-        self.timer_ctrl = self._create_timer_from_config_str(self.timer_ctrl_config_str)
+        self.timer_ctrl = self._create_timer_from_config_str(self.timer_ctrl_config_str, self.compute_control)
         self.publisher_ctrl = self._create_publisher_from_config_str(self.pub_ctrl_config_str)
-        self.subscriber_est = self._create_subscription_from_config_str(self.sub_est_config_str)
+        self.subscriber_est = self._create_subscription_from_config_str(self.sub_est_config_str, self.update_x_hat)
 
         # checks
         assert (

--- a/obelisk/python/obelisk_py/control.py
+++ b/obelisk/python/obelisk_py/control.py
@@ -55,8 +55,8 @@ class ObeliskController(ABC, ObeliskNode):
 
         # create publishers+timers/subscribers
         self.timer_ctrl = self._create_timer_from_config_str(self.timer_ctrl_config_str)
-        self.publisher_ctrl = self._create_publisher_from_config_str(self.pub_ctrl_config_str, "ctrl")
-        self.subscriber_est = self._create_subscription_from_config_str(self.sub_est_config_str, "est")
+        self.publisher_ctrl = self._create_publisher_from_config_str(self.pub_ctrl_config_str)
+        self.subscriber_est = self._create_subscription_from_config_str(self.sub_est_config_str)
 
         # checks
         assert (

--- a/obelisk/python/obelisk_py/estimation.py
+++ b/obelisk/python/obelisk_py/estimation.py
@@ -48,18 +48,17 @@ class ObeliskEstimator(ABC, ObeliskNode):
             self.get_parameter("sub_sensor_config_strs").get_parameter_value().string_array_value
         )
 
-        # create publishers+timers and subscribers
-        self.timer_est = self._create_timer_from_config_str(self.timer_est_config_str)
+        # create publisher+timer
+        self.timer_est = self._create_timer_from_config_str(self.timer_est_config_str, self.compute_state_estimate)
         self.publisher_est = self._create_publisher_from_config_str(self.pub_est_config_str)
         self.subscriber_sensors = []
-        for sensor_config_str in self.sub_sensor_config_strs:
-            sub_sensor = self._create_subscription_from_config_str(sensor_config_str)
-            self.subscriber_sensors.append(sub_sensor)
 
-        # checks
-        assert (
-            self.timer_est.callback == self.compute_state_estimate
-        ), f"The timer callback must be compute_state_estimate! Is {self.timer_est.callback}."
+        # in the derived class, you must create your own sensor subscribers
+        """
+        for sensor_config_str in self.sub_sensor_config_strs:
+            sub_sensor = self._create_subscription_from_config_str(sensor_config_str, self.<sensor_callback>)
+            self.subscriber_sensors.append(sub_sensor)
+        """
 
         return TransitionCallbackReturn.SUCCESS
 

--- a/obelisk/python/obelisk_py/estimation.py
+++ b/obelisk/python/obelisk_py/estimation.py
@@ -50,10 +50,10 @@ class ObeliskEstimator(ABC, ObeliskNode):
 
         # create publishers+timers and subscribers
         self.timer_est = self._create_timer_from_config_str(self.timer_est_config_str)
-        self.publisher_est = self._create_publisher_from_config_str(self.pub_est_config_str, "est")
+        self.publisher_est = self._create_publisher_from_config_str(self.pub_est_config_str)
         self.subscriber_sensors = []
         for sensor_config_str in self.sub_sensor_config_strs:
-            sub_sensor = self._create_subscription_from_config_str(sensor_config_str, "sensor")
+            sub_sensor = self._create_subscription_from_config_str(sensor_config_str)
             self.subscriber_sensors.append(sub_sensor)
 
         # checks

--- a/obelisk/python/obelisk_py/robot.py
+++ b/obelisk/python/obelisk_py/robot.py
@@ -36,10 +36,10 @@ class ObeliskRobot(ABC, ObeliskNode):
         )
 
         # create publishers and subscriber
-        self.subscriber_ctrl = self._create_subscription_from_config_str(self.sub_ctrl_config_str, "ctrl")
+        self.subscriber_ctrl = self._create_subscription_from_config_str(self.sub_ctrl_config_str)
         self.publisher_sensors = []
         for sensor_config_str in self.pub_sensor_config_strs:
-            pub_sensor = self._create_publisher_from_config_str(sensor_config_str, "sensor")
+            pub_sensor = self._create_publisher_from_config_str(sensor_config_str)
             self.publisher_sensors.append(pub_sensor)
 
         # checks
@@ -129,9 +129,7 @@ class ObeliskSimRobot(ObeliskRobot):
 
         if self.pub_true_sim_state_config_str != [""]:
             self.timer_true_sim_state = self._create_timer_from_config_str(self.timer_true_sim_state_config_str)
-            self.publisher_true_sim_state = self._create_publisher_from_config_str(
-                self.pub_true_sim_state_config_str, "true_sim_state"
-            )
+            self.publisher_true_sim_state = self._create_publisher_from_config_str(self.pub_true_sim_state_config_str)
 
             # checks
             assert (

--- a/obelisk/python/obelisk_py/robot.py
+++ b/obelisk/python/obelisk_py/robot.py
@@ -36,16 +36,11 @@ class ObeliskRobot(ABC, ObeliskNode):
         )
 
         # create publishers and subscriber
-        self.subscriber_ctrl = self._create_subscription_from_config_str(self.sub_ctrl_config_str)
+        self.subscriber_ctrl = self._create_subscription_from_config_str(self.sub_ctrl_config_str, self.apply_control)
         self.publisher_sensors = []
         for sensor_config_str in self.pub_sensor_config_strs:
             pub_sensor = self._create_publisher_from_config_str(sensor_config_str)
             self.publisher_sensors.append(pub_sensor)
-
-        # checks
-        assert (
-            self.subscriber_ctrl.callback == self.apply_control
-        ), f"Subscriber callback must be apply_control! Is {self.subscriber_ctrl.callback}."
 
         return TransitionCallbackReturn.SUCCESS
 
@@ -128,7 +123,10 @@ class ObeliskSimRobot(ObeliskRobot):
         )
 
         if self.pub_true_sim_state_config_str != [""]:
-            self.timer_true_sim_state = self._create_timer_from_config_str(self.timer_true_sim_state_config_str)
+            self.timer_true_sim_state = self._create_timer_from_config_str(
+                self.timer_true_sim_state_config_str,
+                self.publish_true_sim_state,
+            )
             self.publisher_true_sim_state = self._create_publisher_from_config_str(self.pub_true_sim_state_config_str)
 
             # checks

--- a/obelisk/python/obelisk_py/sensing.py
+++ b/obelisk/python/obelisk_py/sensing.py
@@ -35,7 +35,7 @@ class ObeliskSensor(ObeliskNode):
         # create publishers
         self.publisher_sensors = []
         for sensor_config_str in self.pub_sensor_config_strs:
-            pub_sensor = self._create_publisher_from_config_str(sensor_config_str, "sensor")
+            pub_sensor = self._create_publisher_from_config_str(sensor_config_str)
             self.publisher_sensors.append(pub_sensor)
 
         return TransitionCallbackReturn.SUCCESS

--- a/obelisk/python/obelisk_py/utils.py
+++ b/obelisk/python/obelisk_py/utils.py
@@ -1,6 +1,6 @@
 import inspect
 from types import ModuleType
-from typing import Type, TypeVar, Union, get_args
+from typing import Optional, Type, TypeVar, Union, get_args
 
 from rclpy.node import Node
 
@@ -19,7 +19,7 @@ def get_classes_in_module(module: ModuleType) -> list[Type]:
 
 
 def check_and_add_obelisk_msg_attr(
-    node: Node, msg_type_name: str, msg_module_or_type: Union[ModuleType, TypeVar], attr_suffix: str
+    node: Node, msg_type_name: str, msg_module_or_type: Union[ModuleType, TypeVar], attr_suffix: Optional[str] = None
 ) -> None:
     """Check if a message type is in a module and add it as an attribute to a node in place.
 
@@ -36,14 +36,16 @@ def check_and_add_obelisk_msg_attr(
     if isinstance(msg_module_or_type, TypeVar):
         msg_module_type_names = [a.__name__ for a in get_args(msg_module_or_type.__bound__)]
         assert msg_type_name in msg_module_type_names, f"{msg_type_name} must be one of {msg_module_type_names}"
-        for a in get_args(msg_module_or_type.__bound__):
-            if msg_type_name == a.__name__:
-                setattr(node, f"msg_type_{attr_suffix}", a)
-                break
+        if attr_suffix is not None:
+            for a in get_args(msg_module_or_type.__bound__):
+                if msg_type_name == a.__name__:
+                    setattr(node, f"msg_type_{attr_suffix}", a)
+                    break
     else:
         msg_module_type_names = [t.__name__ for t in get_classes_in_module(msg_module_or_type)]
         assert msg_type_name in msg_module_type_names, f"{msg_type_name} must be one of {msg_module_type_names}"
-        for msg_module_type_name in msg_module_type_names:
-            if msg_type_name == msg_module_type_name:
-                setattr(node, f"msg_type_{attr_suffix}", getattr(msg_module_or_type, msg_type_name))
-                break
+        if attr_suffix is not None:
+            for msg_module_type_name in msg_module_type_names:
+                if msg_type_name == msg_module_type_name:
+                    setattr(node, f"msg_type_{attr_suffix}", getattr(msg_module_or_type, msg_type_name))
+                    break

--- a/obelisk/python/obelisk_py/utils.py
+++ b/obelisk/python/obelisk_py/utils.py
@@ -1,6 +1,6 @@
 import inspect
 from types import ModuleType
-from typing import Optional, Type, TypeVar, Union, get_args
+from typing import Type, TypeVar, Union, get_args
 
 from rclpy.node import Node
 
@@ -18,9 +18,9 @@ def get_classes_in_module(module: ModuleType) -> list[Type]:
     return classes
 
 
-def check_and_add_obelisk_msg_attr(
-    node: Node, msg_type_name: str, msg_module_or_type: Union[ModuleType, TypeVar], attr_suffix: Optional[str] = None
-) -> None:
+def check_and_get_obelisk_msg_type(
+    node: Node, msg_type_name: str, msg_module_or_type: Union[ModuleType, TypeVar]
+) -> Type:
     """Check if a message type is in a module and add it as an attribute to a node in place.
 
     Parameters:
@@ -28,24 +28,31 @@ def check_and_add_obelisk_msg_attr(
         msg_type_name: The name of the message type to add.
         msg_module_or_type: The module over which we verify the message type. If a TypeVar is passed, we verify that the
             message type is in the bound of the TypeVar.
-        suffix: The suffix to add to the attribute name.
+
+    Returns:
+        The message type.
 
     Raises:
         AssertionError: If the message type is not in the module.
     """
+    msg_type = None
+
     if isinstance(msg_module_or_type, TypeVar):
         msg_module_type_names = [a.__name__ for a in get_args(msg_module_or_type.__bound__)]
         assert msg_type_name in msg_module_type_names, f"{msg_type_name} must be one of {msg_module_type_names}"
-        if attr_suffix is not None:
-            for a in get_args(msg_module_or_type.__bound__):
-                if msg_type_name == a.__name__:
-                    setattr(node, f"msg_type_{attr_suffix}", a)
-                    break
+
+        for a in get_args(msg_module_or_type.__bound__):
+            if msg_type_name == a.__name__:
+                msg_type = a
+                break
     else:
         msg_module_type_names = [t.__name__ for t in get_classes_in_module(msg_module_or_type)]
         assert msg_type_name in msg_module_type_names, f"{msg_type_name} must be one of {msg_module_type_names}"
-        if attr_suffix is not None:
-            for msg_module_type_name in msg_module_type_names:
-                if msg_type_name == msg_module_type_name:
-                    setattr(node, f"msg_type_{attr_suffix}", getattr(msg_module_or_type, msg_type_name))
-                    break
+
+        for msg_module_type_name in msg_module_type_names:
+            if msg_type_name == msg_module_type_name:
+                msg_type = getattr(msg_module_or_type, msg_type_name)
+                break
+
+    assert msg_type is not None, f"Could not find {msg_type_name} in {msg_module_or_type}!"
+    return msg_type

--- a/tests/tests_python/test_control.py
+++ b/tests/tests_python/test_control.py
@@ -45,7 +45,7 @@ def configured_controller(
     """Fixture for the TestObeliskController class with parameters set."""
     parameter_dict = {
         "callback_group_config_strs": ["test_cbg:ReentrantCallbackGroup"],
-        "timer_ctrl_config_str": "timer_period_sec:0.001,callback:compute_control,callback_group:None",
+        "timer_ctrl_config_str": "timer_period_sec:0.001,callback_group:None",
         "pub_ctrl_config_str": (
             "msg_type:PositionSetpoint,"
             "topic:/obelisk/test_controller/control,"
@@ -56,7 +56,6 @@ def configured_controller(
         "sub_est_config_str": (
             "msg_type:EstimatedState,"
             "topic:/obelisk/test_controller/state_estimate,"
-            "callback:update_x_hat,"
             "history_depth:10,"
             "callback_group:None,"
             "non_obelisk:False"

--- a/tests/tests_python/test_node.py
+++ b/tests/tests_python/test_node.py
@@ -116,7 +116,7 @@ def test_create_callback_groups_from_config_str(test_node: ObeliskNode) -> None:
 def test_create_publisher_from_config_str(test_node: ObeliskNode) -> None:
     """Test creating a publisher from a configuration string."""
     config_str = "msg_type:JointEncoder,topic:/test/create_publisher_from_config_str,history_depth:20"
-    publisher = test_node._create_publisher_from_config_str(config_str, "odom")
+    publisher = test_node._create_publisher_from_config_str(config_str)
     assert isinstance(publisher, Publisher)
     assert publisher.topic_name == "/test/create_publisher_from_config_str"
 
@@ -128,10 +128,8 @@ def test_create_subscription_from_config_str(test_node: ObeliskNode) -> None:
         pass
 
     test_node.dummy_callback = dummy_callback
-    config_str = (
-        "msg_type:JointEncoder,topic:/test/create_subscription_from_config_str,callback:dummy_callback,history_depth:20"
-    )
-    subscription = test_node._create_subscription_from_config_str(config_str, "odom")
+    config_str = "msg_type:JointEncoder,topic:/test/create_subscription_from_config_str,history_depth:20"
+    subscription = test_node._create_subscription_from_config_str(config_str, test_node.dummy_callback)
     assert isinstance(subscription, Subscription)
     assert subscription.topic_name == "/test/create_subscription_from_config_str"
 
@@ -144,8 +142,8 @@ def test_create_timer_from_config_str(test_node: ObeliskNode) -> None:
 
     test_node.dummy_timer_callback = dummy_timer_callback
     period = 0.1
-    config_str = f"timer_period_sec:{period},callback:dummy_timer_callback"
-    timer = test_node._create_timer_from_config_str(config_str)
+    config_str = f"timer_period_sec:{period}"
+    timer = test_node._create_timer_from_config_str(config_str, test_node.dummy_timer_callback)
     assert isinstance(timer, Timer)
     assert timer.timer_period_ns == period * 1e9
 

--- a/tests/tests_python/test_robot.py
+++ b/tests/tests_python/test_robot.py
@@ -51,7 +51,6 @@ def configured_robot(
         "sub_ctrl_config_str": (
             "msg_type:PositionSetpoint,"
             "topic:/obelisk/test_robot/ctrl,"
-            "callback:apply_control,"
             "history_depth:10,"
             "callback_group:None,"
             "non_obelisk:False"

--- a/tests/tests_python/test_sim_robot.py
+++ b/tests/tests_python/test_sim_robot.py
@@ -56,7 +56,6 @@ def configured_sim_robot(
         "sub_ctrl_config_str": (
             "msg_type:PositionSetpoint,"
             "topic:/obelisk/test_sim_robot/ctrl,"
-            "callback:apply_control,"
             "history_depth:10,"
             "callback_group:None,"
             "non_obelisk:False"
@@ -78,9 +77,7 @@ def configured_sim_robot(
             ),
         ],
         "n_u": 2,
-        "timer_true_sim_state_config_str": (
-            "timer_period_sec:0.1," "callback:publish_true_sim_state," "callback_group:None"
-        ),
+        "timer_true_sim_state_config_str": ("timer_period_sec:0.1,callback_group:None"),
         "pub_true_sim_state_config_str": (
             "msg_type:TrueSimState,"
             "topic:/obelisk/test_sim_robot/true_sim_state,"


### PR DESCRIPTION
This PR does the following:

- exposes callback groups to timer and subscriber creation functions, removes the callback key from the config string
- exposes the message type to all component creation functions. but, we leave in the ability to pass it in the config string if you want to auto-search among Obelisk message types for convenience.