### PR TITLE
Update how the C++ libraries are configured with cmake

### DIFF
--- a/obelisk/cpp/CMakeLists.txt
+++ b/obelisk/cpp/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16)
 
-project(obelisk_cpp
+project(ObeliskCpp
     VERSION 0.0.1
     LANGUAGES CXX
     DESCRIPTION "Obelisk c++ utils")
@@ -11,4 +11,11 @@ set(CMAKE_CXX_STANDARD 17 CACHE STRING "The C++ standard to use")
 
 add_subdirectory(obelisk_cpp)
 add_subdirectory(zoo)
-add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../../tests/tests_cpp ${CMAKE_CURRENT_BINARY_DIR}/tests)
+
+if (CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+    include(CTest)
+endif()
+
+if (CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME AND BUILD_TESTING)
+    add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../../tests/tests_cpp ${CMAKE_CURRENT_BINARY_DIR}/tests)
+endif()

--- a/obelisk/cpp/obelisk_cpp/CMakeLists.txt
+++ b/obelisk/cpp/obelisk_cpp/CMakeLists.txt
@@ -1,18 +1,16 @@
-message(STATUS "Building Obelisk Cpp")
+message(STATUS "Configuring Obelisk Cpp")
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
-
-# ROS 2 Packages
+# ------- ROS 2 Packages ------- #
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)
 find_package(rcl REQUIRED)
 
-# Obelisk Messages
+# ------- Obelisk Messages ------- #
 find_package(obelisk_control_msgs REQUIRED)
 find_package(obelisk_sensor_msgs REQUIRED)
 find_package(obelisk_estimator_msgs REQUIRED)
@@ -29,7 +27,7 @@ FetchContent_Declare(
 
 FetchContent_Populate(mujoco)
 
-# Setup the Mujoco library
+# ------- Setup the Mujoco library ------- #
 find_library(MUJOCO_LIB mujoco-lib REQUIRED HINTS ${mujoco_SOURCE_DIR}/lib)
 add_library(mujoco-lib SHARED IMPORTED GLOBAL)
 target_include_directories(mujoco-lib INTERFACE ${mujoco_SOURCE_DIR}/include)
@@ -37,34 +35,34 @@ target_include_directories(mujoco-lib INTERFACE ${mujoco_SOURCE_DIR}/include/muj
 
 set_property(TARGET mujoco-lib PROPERTY IMPORTED_LOCATION ${mujoco_SOURCE_DIR}/lib/libmujoco.so)
 
-# GLFW
+# ------- GLFW ------- #
 find_package(glfw3 REQUIRED)
 
+# ------- Source files ------- #
+message(STATUS "cmake source dir: ${CMAKE_CURRENT_SOURCE_DIR}")
+set(CORE_INC "${CMAKE_CURRENT_SOURCE_DIR}/include")
 
-# Source files
-set(OBELISK_CPP_INC "${obelisk_cpp_SOURCE_DIR}/obelisk_cpp/include")
-set(OBELISK_CPP_HEADER_LIST
-        "${OBELISK_CPP_INC}/obelisk_node.h"
-        "${OBELISK_CPP_INC}/obelisk_controller.h"
-        "${OBELISK_CPP_INC}/obelisk_estimator.h"
-        "${OBELISK_CPP_INC}/obelisk_sensor.h"
-        "${OBELISK_CPP_INC}/obelisk_robot.h"
-        "${OBELISK_CPP_INC}/obelisk_sim_robot.h"
-        "${OBELISK_CPP_INC}/obelisk_mujoco_sim_robot")
+# These are not currently used, but might be used in the future
+# set(OBELISK_CPP_HEADER_LIST
+#         "${CORE_INC}/obelisk_node.h"
+#         "${CORE_INC}/obelisk_controller.h"
+#         "${CORE_INC}/obelisk_estimator.h"
+#         "${CORE_INC}/obelisk_sensor.h"
+#         "${CORE_INC}/obelisk_robot.h"
+#         "${CORE_INC}/obelisk_sim_robot.h"
+#         "${CORE_INC}/obelisk_mujoco_sim_robot")
 
-add_library(ObeliskCpp INTERFACE)
-target_include_directories(ObeliskCpp INTERFACE include ${mujoco_SOURCE_DIR}/include)
+# ------- Making the library ------- #
+add_library(Core INTERFACE)
+add_library(Obelisk::Core ALIAS Core)   # Namespaced alias
+target_include_directories(Core INTERFACE ${CORE_INC} ${mujoco_SOURCE_DIR}/include)
 
-target_link_libraries(ObeliskCpp INTERFACE mujoco-lib glfw)
+target_link_libraries(Core INTERFACE mujoco-lib glfw)
 
-ament_target_dependencies(ObeliskCpp INTERFACE
+ament_target_dependencies(Core INTERFACE
   rclcpp
   rclcpp_lifecycle
   obelisk_control_msgs
   obelisk_estimator_msgs
   obelisk_sensor_msgs
   std_msgs)
-
-target_include_directories(ObeliskCpp INTERFACE
-    $<BUILD_INTERFACE:${OBELISK_CPP_INC}>
-    $<INSTALL_INTERFACE:$obelisk_cpp/include>)

--- a/obelisk/cpp/obelisk_cpp/CMakeLists.txt
+++ b/obelisk/cpp/obelisk_cpp/CMakeLists.txt
@@ -28,7 +28,8 @@ FetchContent_Declare(
 FetchContent_Populate(mujoco)
 
 # ------- Setup the Mujoco library ------- #
-find_library(MUJOCO_LIB mujoco-lib REQUIRED HINTS ${mujoco_SOURCE_DIR}/lib)
+message(STATUS "mujoco source dir: ${mujoco_SOURCE_DIR}")
+find_library(MUJOCO_LIB mujoco REQUIRED HINTS ${mujoco_SOURCE_DIR}/lib)
 add_library(mujoco-lib SHARED IMPORTED GLOBAL)
 target_include_directories(mujoco-lib INTERFACE ${mujoco_SOURCE_DIR}/include)
 target_include_directories(mujoco-lib INTERFACE ${mujoco_SOURCE_DIR}/include/mujoco)
@@ -53,13 +54,13 @@ set(CORE_INC "${CMAKE_CURRENT_SOURCE_DIR}/include")
 #         "${CORE_INC}/obelisk_mujoco_sim_robot")
 
 # ------- Making the library ------- #
-add_library(Core INTERFACE)
-add_library(Obelisk::Core ALIAS Core)   # Namespaced alias
-target_include_directories(Core INTERFACE ${CORE_INC} ${mujoco_SOURCE_DIR}/include)
+add_library(ObkCore INTERFACE)
+add_library(Obelisk::Core ALIAS ObkCore)   # Namespaced alias
+target_include_directories(ObkCore INTERFACE ${CORE_INC} ${mujoco_SOURCE_DIR}/include)
 
-target_link_libraries(Core INTERFACE mujoco-lib glfw)
+target_link_libraries(ObkCore INTERFACE mujoco-lib glfw)
 
-ament_target_dependencies(Core INTERFACE
+ament_target_dependencies(ObkCore INTERFACE
   rclcpp
   rclcpp_lifecycle
   obelisk_control_msgs

--- a/obelisk/cpp/zoo/CMakeLists.txt
+++ b/obelisk/cpp/zoo/CMakeLists.txt
@@ -1,30 +1,30 @@
-message(STATUS "Building Obelisk Zoo")
+message(STATUS "Configuring Obelisk Zoo")
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-# ROS 2 Packages
+# ------- ROS 2 Packages ------- #
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)
 find_package(rcl REQUIRED)
 
-set(OBELISK_ZOO_INC "${obelisk_cpp_SOURCE_DIR}/obelisk_cpp/include")
-set(OBELISK_ZOO_HEADER_LIST
-        "${OBELISK_CPP_INC}/jointencoders_passthrough_estimator.h"
-        "${OBELISK_CPP_INC}/position_setpoint_controller.h")
+set(ZOO_INC "${obelisk_cpp_SOURCE_DIR}/obelisk_cpp/include")
 
+# Not currently used, but might be used in the future
+# set(ZOO_HEADER_LIST
+#         "${OBELISK_CPP_INC}/jointencoders_passthrough_estimator.h"
+#         "${OBELISK_CPP_INC}/position_setpoint_controller.h")
+
+# ------- Making the library ------- #
 add_library(Zoo INTERFACE)
+add_library(Obelisk::Zoo ALIAS Zoo)
 
 target_include_directories(Zoo INTERFACE include)
 
-target_link_libraries(Zoo INTERFACE ObeliskCpp)
+target_link_libraries(Zoo INTERFACE Obelisk::Core)
 
 ament_target_dependencies(Zoo INTERFACE
   rclcpp
   rclcpp_lifecycle)
-
-target_include_directories(Zoo INTERFACE
-    $<BUILD_INTERFACE:${OBELISK_ZOO_INC}>
-    $<INSTALL_INTERFACE:$zoo/include>)

--- a/obelisk_ws/src/cpp/obelisk_control_cpp/CMakeLists.txt
+++ b/obelisk_ws/src/cpp/obelisk_control_cpp/CMakeLists.txt
@@ -11,22 +11,15 @@ find_package(ament_cmake REQUIRED)
 # Get the Obelisk library
 include(FetchContent)
 FetchContent_Declare(
-  ObeliskCpp
-  SOURCE_DIR $ENV{OBELISK_ROOT}/obelisk/cpp/obelisk_cpp
+  Obelisk
+  SOURCE_DIR $ENV{OBELISK_ROOT}/obelisk/cpp
 )
 
-FetchContent_MakeAvailable(ObeliskCpp)
-
-# Get Obelisk zoo
-FetchContent_Declare(
-  Zoo
-  SOURCE_DIR $ENV{OBELISK_ROOT}/obelisk/cpp/zoo
-)
-
-FetchContent_MakeAvailable(Zoo)
+# Lets us Get Obelisk::Core and Obelisk::Zoo
+FetchContent_MakeAvailable(Obelisk)
 
 add_executable(example_position_setpoint_controller src/example_position_setpoint_controller.cpp)
-target_link_libraries(example_position_setpoint_controller PUBLIC ObeliskCpp Zoo)
+target_link_libraries(example_position_setpoint_controller PUBLIC Obelisk::Core Obelisk::Zoo)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/obelisk_ws/src/cpp/obelisk_estimation_cpp/CMakeLists.txt
+++ b/obelisk_ws/src/cpp/obelisk_estimation_cpp/CMakeLists.txt
@@ -11,22 +11,15 @@ find_package(ament_cmake REQUIRED)
 # Get the Obelisk library
 include(FetchContent)
 FetchContent_Declare(
-  ObeliskCpp
-  SOURCE_DIR $ENV{OBELISK_ROOT}/obelisk/cpp/obelisk_cpp
+  Obelisk
+  SOURCE_DIR $ENV{OBELISK_ROOT}/obelisk/cpp
 )
 
-FetchContent_MakeAvailable(ObeliskCpp)
-
-# Get Obelisk zoo
-FetchContent_Declare(
-  Zoo
-  SOURCE_DIR $ENV{OBELISK_ROOT}/obelisk/cpp/zoo
-)
-
-FetchContent_MakeAvailable(Zoo)
+# Lets us Get Obelisk::Core and Obelisk::Zoo
+FetchContent_MakeAvailable(Obelisk)
 
 add_executable(jointencoders_passthrough_estimator src/jointencoders_passthrough_estimator.cpp)
-target_link_libraries(jointencoders_passthrough_estimator PUBLIC ObeliskCpp Zoo)
+target_link_libraries(jointencoders_passthrough_estimator PUBLIC Obelisk::Core Obelisk::Zoo)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
@@ -38,6 +31,5 @@ endif()
 install(TARGETS
   jointencoders_passthrough_estimator
   DESTINATION lib/${PROJECT_NAME})
-
 
 ament_package()

--- a/obelisk_ws/src/cpp/obelisk_sensing_cpp/CMakeLists.txt
+++ b/obelisk_ws/src/cpp/obelisk_sensing_cpp/CMakeLists.txt
@@ -11,11 +11,12 @@ find_package(ament_cmake REQUIRED)
 # Get the Obelisk library
 include(FetchContent)
 FetchContent_Declare(
-  ObeliskCpp
-  SOURCE_DIR $ENV{OBELISK_ROOT}/obelisk/cpp/obelisk_cpp
+  Obelisk
+  SOURCE_DIR $ENV{OBELISK_ROOT}/obelisk/cpp
 )
 
-FetchContent_MakeAvailable(ObeliskCpp)
+# Lets us Get Obelisk::Core and Obelisk::Zoo
+FetchContent_MakeAvailable(Obelisk)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/obelisk_ws/src/cpp/obelisk_sim_cpp/CMakeLists.txt
+++ b/obelisk_ws/src/cpp/obelisk_sim_cpp/CMakeLists.txt
@@ -12,14 +12,15 @@ find_package(rclcpp REQUIRED)
 # Get the Obelisk library
 include(FetchContent)
 FetchContent_Declare(
-  ObeliskCpp
-  SOURCE_DIR $ENV{OBELISK_ROOT}/obelisk/cpp/obelisk_cpp
+  Obelisk
+  SOURCE_DIR $ENV{OBELISK_ROOT}/obelisk/cpp
 )
 
-FetchContent_MakeAvailable(ObeliskCpp)
+# Lets us Get Obelisk::Core and Obelisk::Zoo
+FetchContent_MakeAvailable(Obelisk)
 
 add_executable(obelisk_mujoco_robot src/obelisk_mujoco_robot.cpp)
-target_link_libraries(obelisk_mujoco_robot PUBLIC ObeliskCpp)
+target_link_libraries(obelisk_mujoco_robot PUBLIC Obelisk::Core)
 
 ament_target_dependencies(obelisk_mujoco_robot PUBLIC rclcpp)
 

--- a/tests/tests_cpp/CMakeLists.txt
+++ b/tests/tests_cpp/CMakeLists.txt
@@ -1,6 +1,6 @@
-message(STATUS "Building obelisk_cpp tests")
+message(STATUS "Configuring obelisk_cpp tests")
 
-# Catch2 for testing
+# ------- Catch2 for testing ------- #
 include(FetchContent)
 
 FetchContent_Declare(
@@ -30,7 +30,7 @@ add_executable(NodeTest
     claude_obelisk_estimator_test.cpp)
 
 target_link_libraries(NodeTest PRIVATE Catch2::Catch2WithMain)
-target_link_libraries(NodeTest PUBLIC ObeliskCpp)
+target_link_libraries(NodeTest PUBLIC Obelisk::Core)
 
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)

--- a/tests/tests_cpp/CMakeLists.txt
+++ b/tests/tests_cpp/CMakeLists.txt
@@ -38,5 +38,4 @@ find_package(std_msgs REQUIRED)
 ament_target_dependencies(NodeTest PUBLIC rclcpp std_msgs)
 
 include(Catch)
-include(CTest)
 catch_discover_tests(NodeTest)


### PR DESCRIPTION
Updating the CMake for the C++ Obelisk library to support being used with `FetchContent`. Now the user can put the following in their CMake to use the library:

```
include(FetchContent)
FetchContent_Declare(
  Obelisk
  SOURCE_DIR $ENV{OBELISK_ROOT}/obelisk/cpp
)

# Lets us Get Obelisk::Core and Obelisk::Zoo
FetchContent_MakeAvailable(Obelisk)
```
Also added namespaced targets and change the names to match the python side.