### PR TITLE
Specify full ROS package name in configuration yaml file

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,6 +35,7 @@ RUN apt-get update && apt-get install -y \
     x11-apps \
     libyaml-dev \
     mesa-common-dev \
+    libglfw3-dev \
     locales \
     sudo && \
     rm -rf /var/lib/apt/lists/* && \

--- a/obelisk/python/obelisk_py/utils/launch_utils.py
+++ b/obelisk/python/obelisk_py/utils/launch_utils.py
@@ -22,7 +22,7 @@ def load_config_file(file_path: Union[str, Path], package_name: Optional[str] = 
             'obelisk_ros' package is assumed.
 
     Returns:
-        A dictionary containing the configuration settings.
+        config: A dictionary containing the configuration settings.
     """
     file_path = str(file_path)
     if not file_path.startswith("/"):
@@ -183,16 +183,9 @@ def get_launch_actions_from_node_settings(
     assert node_type in ["control", "estimation", "robot", "sensing"]
 
     def _single_component_launch_actions(node_settings: Dict, suffix: Optional[int] = None) -> List:
-        impl = node_settings["impl"]
+        package = node_settings["pkg"]
         executable = node_settings["executable"]
-
-        # parsing package name and parameters_dict based on node_type
-        if node_type == "robot" and str(node_settings["is_simulated"]).lower() == "true":
-            package = f"obelisk_sim_{'py' if impl == 'python' else 'cpp'}"
-            parameters_dict = get_parameters_dict(node_settings)
-        else:
-            package = f"obelisk_{node_type}_{'py' if impl == 'python' else 'cpp'}"
-            parameters_dict = get_parameters_dict(node_settings)
+        parameters_dict = get_parameters_dict(node_settings)
 
         launch_actions = []
         component_node = LifecycleNode(

--- a/obelisk_ws/src/obelisk_ros/config/dummy.yaml
+++ b/obelisk_ws/src/obelisk_ros/config/dummy.yaml
@@ -1,7 +1,7 @@
 config: dummy
 onboard:
   control:
-    impl: python
+    pkg: obelisk_control_py
     executable: example_position_setpoint_controller
     # callback_groups:
     publishers:
@@ -28,7 +28,7 @@ onboard:
         callback_group: None
         # callback_key: timer_callback1
   estimation:
-    impl: python
+    pkg: obelisk_estimation_py
     executable: jointencoders_passthrough_estimator
     # callback_groups:
     publishers:
@@ -57,7 +57,7 @@ onboard:
   # sensing:
   robot:
     is_simulated: True
-    impl: python
+    pkg: obelisk_sim_py
     executable: obelisk_mujoco_robot
     # callback_groups:
     # publishers:

--- a/obelisk_ws/src/obelisk_ros/config/dummy_cpp.yaml
+++ b/obelisk_ws/src/obelisk_ros/config/dummy_cpp.yaml
@@ -1,7 +1,7 @@
 config: dummy
 onboard:
   control:
-    impl: cpp
+    pkg: obelisk_control_cpp
     executable: example_position_setpoint_controller
     # callback_groups:
     publishers:
@@ -28,7 +28,7 @@ onboard:
         callback_group: None
         # callback_key: timer_callback1
   estimation:
-    impl: cpp
+    pkg: obelisk_estimation_cpp
     executable: jointencoders_passthrough_estimator
     # callback_groups:
     publishers:
@@ -57,7 +57,7 @@ onboard:
   # sensing:
   robot:
     is_simulated: True
-    impl: cpp
+    pkg: obelisk_sim_cpp
     executable: obelisk_mujoco_robot
     # callback_groups:
     # publishers:


### PR DESCRIPTION
This PR makes it so that the user can specify the full name of the package in the config.yaml (versus specifying the `impl` field)