### PR TITLE
Multinode settings

### DIFF
--- a/docker/docker-compose-no-gpu.yml
+++ b/docker/docker-compose-no-gpu.yml
@@ -27,6 +27,7 @@ services:
       - /tmp/.X11-unix:/tmp/.X11-unix
       - $HOME/.Xauthority:$HOME/.Xauthority:rw
       - $HOME/.bashrc:$HOME/.bashrc
+      - /etc/sysctl.d/60-cyclonedds.conf:/etc/sysctl.d/60-cyclonedds.conf
     ports:
       - 7007:7007
     privileged: true

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -28,6 +28,7 @@ services:
       - /tmp/.X11-unix:/tmp/.X11-unix
       - $HOME/.Xauthority:$HOME/.Xauthority:rw
       - $HOME/.bashrc:$HOME/.bashrc
+      - /etc/sysctl.d/60-cyclonedds.conf:/etc/sysctl.d/60-cyclonedds.conf
     ports:
       - 7007:7007
     privileged: true

--- a/obelisk/python/obelisk_py/core/utils/launch_utils.py
+++ b/obelisk/python/obelisk_py/core/utils/launch_utils.py
@@ -312,13 +312,10 @@ def get_launch_actions_from_node_settings(
         ]
         return launch_actions
 
-    if node_type == "sensing":
-        node_launch_actions = []
-        for i, sensor_settings in enumerate(node_settings):
-            node_launch_actions += _single_component_launch_actions(sensor_settings, suffix=i)
-        return node_launch_actions
-    else:
-        return _single_component_launch_actions(node_settings)
+    node_launch_actions = []
+    for i, node_setting in enumerate(node_settings):
+        node_launch_actions += _single_component_launch_actions(node_setting, suffix=i)
+    return node_launch_actions
 
 
 def setup_logging_dir(config_name: str) -> str:

--- a/obelisk_ws/src/obelisk_ros/config/dummy_cpp.yaml
+++ b/obelisk_ws/src/obelisk_ros/config/dummy_cpp.yaml
@@ -1,84 +1,84 @@
 config: dummy
 onboard:
   control:
-    pkg: obelisk_control_cpp
-    executable: example_position_setpoint_controller
-    # callback_groups:
-    publishers:
-      - ros_parameter: pub_ctrl_setting
-        # key: pub1
-        topic: /obelisk/dummy/ctrl
-        msg_type: PositionSetpoint
-        history_depth: 10
-        callback_group: None
-        non_obelisk: False
-    subscribers:
-      - ros_parameter: sub_est_setting
-        # key: sub1
-        topic: /obelisk/dummy/est
-        msg_type: EstimatedState
-        history_depth: 10
-        # callback_key: sub_callback1
-        callback_group: None
-        non_obelisk: False
-    timers:
-      - ros_parameter: timer_ctrl_setting
-        # key: timer1
-        timer_period_sec: 0.001
-        callback_group: None
-        # callback_key: timer_callback1
+    - pkg: obelisk_control_cpp
+      executable: example_position_setpoint_controller
+      # callback_groups:
+      publishers:
+        - ros_parameter: pub_ctrl_setting
+          # key: pub1
+          topic: /obelisk/dummy/ctrl
+          msg_type: PositionSetpoint
+          history_depth: 10
+          callback_group: None
+          non_obelisk: False
+      subscribers:
+        - ros_parameter: sub_est_setting
+          # key: sub1
+          topic: /obelisk/dummy/est
+          msg_type: EstimatedState
+          history_depth: 10
+          # callback_key: sub_callback1
+          callback_group: None
+          non_obelisk: False
+      timers:
+        - ros_parameter: timer_ctrl_setting
+          # key: timer1
+          timer_period_sec: 0.001
+          callback_group: None
+          # callback_key: timer_callback1
   estimation:
-    pkg: obelisk_estimation_cpp
-    executable: jointencoders_passthrough_estimator
-    # callback_groups:
-    publishers:
-      - ros_parameter: pub_est_setting
-        # key: pub1
-        topic: /obelisk/dummy/est
-        msg_type: EstimatedState
-        history_depth: 10
-        callback_group: None
-        non_obelisk: False
-    subscribers:
-      - ros_parameter: sub_sensor_setting
-        # key: sub1
-        topic: /obelisk/dummy/sensor
-        msg_type: JointEncoders
-        history_depth: 10
-        # callback_key: sub_callback1
-        callback_group: None
-        non_obelisk: False
-    timers:
-      - ros_parameter: timer_est_setting
-        # key: timer1
-        timer_period_sec: 0.001
-        callback_group: None
-        # callback_key: timer_callback1
+    - pkg: obelisk_estimation_cpp
+      executable: jointencoders_passthrough_estimator
+      # callback_groups:
+      publishers:
+        - ros_parameter: pub_est_setting
+          # key: pub1
+          topic: /obelisk/dummy/est
+          msg_type: EstimatedState
+          history_depth: 10
+          callback_group: None
+          non_obelisk: False
+      subscribers:
+        - ros_parameter: sub_sensor_setting
+          # key: sub1
+          topic: /obelisk/dummy/sensor
+          msg_type: JointEncoders
+          history_depth: 10
+          # callback_key: sub_callback1
+          callback_group: None
+          non_obelisk: False
+      timers:
+        - ros_parameter: timer_est_setting
+          # key: timer1
+          timer_period_sec: 0.001
+          callback_group: None
+          # callback_key: timer_callback1
   # sensing:
   robot:
-    is_simulated: True
-    pkg: obelisk_sim_cpp
-    executable: obelisk_mujoco_robot
-    # callback_groups:
-    # publishers:
-    subscribers:
-      - ros_parameter: sub_ctrl_setting
-        # key: sub1
-        topic: /obelisk/dummy/ctrl
-        msg_type: PositionSetpoint
-        history_depth: 10
-        # callback_key: sub_callback1
-        callback_group: None
-        non_obelisk: False
-    sim:
-      - ros_parameter: mujoco_setting
-        model_xml_path: dummy/dummy.xml
-        n_u: 1
-        time_step: 0.002
-        num_steps_per_viz: 5
-        sensor_settings:
-        - topic: /obelisk/dummy/sensor
-          dt: 0.001
-          sensor_type: jointpos
-          sensor_names:
-          - sensor_joint1
+    - is_simulated: True
+      pkg: obelisk_sim_cpp
+      executable: obelisk_mujoco_robot
+      # callback_groups:
+      # publishers:
+      subscribers:
+        - ros_parameter: sub_ctrl_setting
+          # key: sub1
+          topic: /obelisk/dummy/ctrl
+          msg_type: PositionSetpoint
+          history_depth: 10
+          # callback_key: sub_callback1
+          callback_group: None
+          non_obelisk: False
+      sim:
+        - ros_parameter: mujoco_setting
+          model_xml_path: dummy/dummy.xml
+          n_u: 1
+          time_step: 0.002
+          num_steps_per_viz: 5
+          sensor_settings:
+          - topic: /obelisk/dummy/sensor
+            dt: 0.001
+            sensor_type: jointpos
+            sensor_names:
+            - sensor_joint1

--- a/obelisk_ws/src/obelisk_ros/config/dummy_py.yaml
+++ b/obelisk_ws/src/obelisk_ros/config/dummy_py.yaml
@@ -1,76 +1,76 @@
 config: dummy
 onboard:
   control:
-    pkg: obelisk_control_py
-    executable: example_position_setpoint_controller
-    # callback_groups:
-    publishers:
-      - ros_parameter: pub_ctrl_setting
-        topic: /obelisk/dummy/ctrl
-        msg_type: PositionSetpoint
-        key: "asdf"
-        history_depth: 10
-        callback_group: None
-        non_obelisk: False
-    subscribers:
-      - ros_parameter: sub_est_setting
-        topic: /obelisk/dummy/est
-        msg_type: EstimatedState
-        history_depth: 10
-        callback_group: None
-        non_obelisk: False
-    timers:
-      - ros_parameter: timer_ctrl_setting
-        timer_period_sec: 0.001
-        callback_group: None
+    - pkg: obelisk_control_py
+      executable: example_position_setpoint_controller
+      # callback_groups:
+      publishers:
+        - ros_parameter: pub_ctrl_setting
+          topic: /obelisk/dummy/ctrl
+          msg_type: PositionSetpoint
+          key: "asdf"
+          history_depth: 10
+          callback_group: None
+          non_obelisk: False
+      subscribers:
+        - ros_parameter: sub_est_setting
+          topic: /obelisk/dummy/est
+          msg_type: EstimatedState
+          history_depth: 10
+          callback_group: None
+          non_obelisk: False
+      timers:
+        - ros_parameter: timer_ctrl_setting
+          timer_period_sec: 0.001
+          callback_group: None
   estimation:
-    pkg: obelisk_estimation_py
-    executable: jointencoders_passthrough_estimator
-    # callback_groups:
-    publishers:
-      - ros_parameter: pub_est_setting
-        topic: /obelisk/dummy/est
-        msg_type: EstimatedState
-        history_depth: 10
-        callback_group: None
-        non_obelisk: False
-    subscribers:
-      - ros_parameter: sub_sensor_setting
-        # key: sub1
-        topic: /obelisk/dummy/sensor
-        msg_type: JointEncoders
-        history_depth: 10
-        callback_group: None
-        non_obelisk: False
-    timers:
-      - ros_parameter: timer_est_setting
-        timer_period_sec: 0.001
-        callback_group: None
+    - pkg: obelisk_estimation_py
+      executable: jointencoders_passthrough_estimator
+      # callback_groups:
+      publishers:
+        - ros_parameter: pub_est_setting
+          topic: /obelisk/dummy/est
+          msg_type: EstimatedState
+          history_depth: 10
+          callback_group: None
+          non_obelisk: False
+      subscribers:
+        - ros_parameter: sub_sensor_setting
+          # key: sub1
+          topic: /obelisk/dummy/sensor
+          msg_type: JointEncoders
+          history_depth: 10
+          callback_group: None
+          non_obelisk: False
+      timers:
+        - ros_parameter: timer_est_setting
+          timer_period_sec: 0.001
+          callback_group: None
   # sensing:
   robot:
     # `is_simulated` is critical for parsing correct package in the obelisk launch file
-    is_simulated: True
-    pkg: obelisk_sim_py
-    executable: obelisk_mujoco_robot
-    # callback_groups:
-    # publishers:
-    subscribers:
-      - ros_parameter: sub_ctrl_setting
-        # key: sub1
-        topic: /obelisk/dummy/ctrl
-        msg_type: PositionSetpoint
-        history_depth: 10
-        callback_group: None
-        non_obelisk: False
-    sim:
-      - ros_parameter: mujoco_setting
-        model_xml_path: dummy/dummy.xml
-        n_u: 1
-        time_step: 0.002
-        num_steps_per_viz: 5
-        sensor_settings:
-        - topic: /obelisk/dummy/sensor
-          dt: 0.001
-          sensor_type: jointpos
-          sensor_names:
-          - sensor_joint1
+    - is_simulated: True
+      pkg: obelisk_sim_py
+      executable: obelisk_mujoco_robot
+      # callback_groups:
+      # publishers:
+      subscribers:
+        - ros_parameter: sub_ctrl_setting
+          # key: sub1
+          topic: /obelisk/dummy/ctrl
+          msg_type: PositionSetpoint
+          history_depth: 10
+          callback_group: None
+          non_obelisk: False
+      sim:
+        - ros_parameter: mujoco_setting
+          model_xml_path: dummy/dummy.xml
+          n_u: 1
+          time_step: 0.002
+          num_steps_per_viz: 5
+          sensor_settings:
+          - topic: /obelisk/dummy/sensor
+            dt: 0.001
+            sensor_type: jointpos
+            sensor_names:
+            - sensor_joint1

--- a/obelisk_ws/src/obelisk_ros/config/leap_py.yaml
+++ b/obelisk_ws/src/obelisk_ros/config/leap_py.yaml
@@ -1,93 +1,90 @@
 config: leap
 onboard:
   control:
-    pkg: obelisk_control_py
-    executable: leap_controller
-    # callback_groups:
-    publishers:
-      - ros_parameter: pub_ctrl_setting
-        topic: /obelisk/leap/ctrl
-        msg_type: PositionSetpoint
-        history_depth: 10
-        callback_group: None
-        non_obelisk: False
-    subscribers:
-      - ros_parameter: sub_est_setting
-        topic: /obelisk/leap/est
-        msg_type: EstimatedState
-        history_depth: 10
-        callback_group: None
-        non_obelisk: False
-    timers:
-      - ros_parameter: timer_ctrl_setting
-        timer_period_sec: 0.001
-        callback_group: None
+    - pkg: obelisk_control_py
+      executable: leap_controller
+      # callback_groups:
+      publishers:
+        - ros_parameter: pub_ctrl_setting
+          topic: /obelisk/leap/ctrl
+          msg_type: PositionSetpoint
+          history_depth: 10
+          callback_group: None
+          non_obelisk: False
+      subscribers:
+        - ros_parameter: sub_est_setting
+          topic: /obelisk/leap/est
+          msg_type: EstimatedState
+          history_depth: 10
+          callback_group: None
+          non_obelisk: False
+      timers:
+        - ros_parameter: timer_ctrl_setting
+          timer_period_sec: 0.001
+          callback_group: None
   estimation:
-    pkg: obelisk_estimation_py
-    executable: jointencoders_passthrough_estimator
-    # callback_groups:
-    publishers:
-      - ros_parameter: pub_est_setting
-        topic: /obelisk/leap/est
-        msg_type: EstimatedState
-        history_depth: 10
-        callback_group: None
-        non_obelisk: False
-    subscribers:
-      - ros_parameter: sub_sensor_setting
-        # key: sub1
-        topic: /obelisk/leap/sensor
-        msg_type: JointEncoders
-        history_depth: 10
-        callback_group: None
-        non_obelisk: False
-    timers:
-      - ros_parameter: timer_est_setting
-        timer_period_sec: 0.001
-        callback_group: None
+    - pkg: obelisk_estimation_py
+      executable: jointencoders_passthrough_estimator
+      # callback_groups:
+      publishers:
+        - ros_parameter: pub_est_setting
+          topic: /obelisk/leap/est
+          msg_type: EstimatedState
+          history_depth: 10
+          callback_group: None
+          non_obelisk: False
+      subscribers:
+        - ros_parameter: sub_sensor_setting
+          # key: sub1
+          topic: /obelisk/leap/sensor
+          msg_type: JointEncoders
+          history_depth: 10
+          callback_group: None
+          non_obelisk: False
+      timers:
+        - ros_parameter: timer_est_setting
+          timer_period_sec: 0.001
+          callback_group: None
   # sensing:
   robot:
-    # `is_simulated` is critical for parsing correct package in the obelisk launch file
-
     # === simulation ===
-    # is_simulated: False
-    # pkg: obelisk_leap_py
-    # executable: obelisk_leap_hand
+    # - is_simulated: False
+    #   pkg: obelisk_leap_py
+    #   executable: obelisk_leap_hand
     # === hardware ===
-    is_simulated: True
-    pkg: obelisk_sim_py
-    executable: obelisk_mujoco_robot
+    - is_simulated: True
+      pkg: obelisk_sim_py
+      executable: obelisk_mujoco_robot
     # ==================
-
-    # callback_groups:
-    publishers:
-      - ros_parameter: pub_sensor_setting
-        topic: /obelisk/leap/sensor
-        msg_type: JointEncoders
-        history_depth: 10
-        callback_group: None
-        non_obelisk: False
-    subscribers:
-      - ros_parameter: sub_ctrl_setting
-        # key: sub1
-        topic: /obelisk/leap/ctrl
-        msg_type: PositionSetpoint
-        history_depth: 10
-        callback_group: None
-        non_obelisk: False
-    sim:
-      - ros_parameter: mujoco_setting
-        model_xml_path: leap/leap_hand.xml
-        n_u: 16
-        time_step: 0.002
-        num_steps_per_viz: 5
-        sensor_settings:
-        - topic: /obelisk/leap/sensor
-          dt: 0.001
-          sensor_type: jointpos
-          sensor_names:
-          - trace1
-    timers:
-      - ros_parameter: timer_sensor_setting
-        timer_period_sec: 0.02
-        callback_group: None
+      # callback_groups:
+      publishers:
+        - ros_parameter: pub_sensor_setting
+          topic: /obelisk/leap/sensor
+          msg_type: JointEncoders
+          history_depth: 10
+          callback_group: None
+          non_obelisk: False
+      subscribers:
+        - ros_parameter: sub_ctrl_setting
+          # key: sub1
+          topic: /obelisk/leap/ctrl
+          msg_type: PositionSetpoint
+          history_depth: 10
+          callback_group: None
+          non_obelisk: False
+      sim:
+        - ros_parameter: mujoco_setting
+          model_xml_path: leap/leap_hand.xml
+          n_u: 16
+          time_step: 0.002
+          num_steps_per_viz: 5
+          sensor_settings:
+          - topic: /obelisk/leap/sensor
+            dt: 0.001
+            sensor_type: jointpos
+            sensor_names:
+            - trace1
+      timers:
+        - ros_parameter: timer_sensor_setting
+          timer_period_sec: 0.02
+          callback_group: None

--- a/pixi.toml
+++ b/pixi.toml
@@ -54,7 +54,6 @@ channels = ["robostack-staging"]
 
 [feature.ros2base.dependencies]
 ros-humble-ros-base = "*"
-ros-humble-cyclonedds = "*"
 colcon-common-extensions = "*"
 
 # TODO(ahl): this was just a test to see if we could install many

--- a/pixi.toml
+++ b/pixi.toml
@@ -54,6 +54,7 @@ channels = ["robostack-staging"]
 
 [feature.ros2base.dependencies]
 ros-humble-ros-base = "*"
+ros-humble-cyclonedds = "*"
 colcon-common-extensions = "*"
 
 # TODO(ahl): this was just a test to see if we could install many

--- a/scripts/source_obelisk.sh
+++ b/scripts/source_obelisk.sh
@@ -38,5 +38,27 @@ else
     printf '\n%s\n%s\n%s\n' "$start_marker" "$cmd" "$end_marker" >> ~/.bashrc
 fi
 
+# makes cyclone DDS the default ROS2 middleware
+cmd_local='if which python | grep -q ".pixi"; then
+    export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
+fi'
+cmd_global='export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp'
+start_marker="# >>> make cyclone DDS the rmw default >>>"
+end_marker="# <<< make cyclone DDS the rmw default <<<"
+if [ "$GLOBAL" == "true" ]; then
+    cmd="$cmd_global"
+else
+    cmd="$cmd_local"
+fi
+if grep -Fq "$start_marker" ~/.bashrc && grep -Fq "$end_marker" ~/.bashrc; then
+    awk -v start="$start_marker" -v end="$end_marker" -v cmd="$cmd" '
+        $0 == start {print; print cmd; f=1; next}
+        $0 == end {f=0}
+        !f
+    ' ~/.bashrc > ~/.bashrc.tmp && cp ~/.bashrc.tmp ~/.bashrc && rm ~/.bashrc.tmp
+else
+    printf '\n%s\n%s\n%s\n' "$start_marker" "$cmd" "$end_marker" >> ~/.bashrc
+fi
+
 source ~/.bashrc
 echo -e "\033[1;32mObelisk sourced!\033[0m"

--- a/tests/tests_python/test_assets/test_config.yaml
+++ b/tests/tests_python/test_assets/test_config.yaml
@@ -1,43 +1,43 @@
 onboard:
   control:
-    pkg: test_pkg1
-    executable: test_controller
-    callback_groups:
-      cbg1: MutuallyExclusiveCallbackGroup
-      cbg2: ReentrantCallbackGroup
-    publishers:
-      - ros_parameter: pub_ctrl_settings1
-        key: pub1
-        topic: /test/controller/pub1
-        msg_type: TestMsg
-        history_depth: 10
-        callback_group: cbg1
-        non_obelisk: False
-    subscribers:
-      - ros_parameter: sub_ctrl_settings1
-        key: sub1
-        topic: /test/controller/sub1
-        msg_type: TestMsg
-        history_depth: 5
-        callback_key: sub_callback1
-        callback_group: cbg2
-        non_obelisk: False
-    timers:
-      - ros_parameter: timer_ctrl_settings1
-        key: timer1
-        timer_period_sec: 0.1
-        callback_group: cbg1
-        callback_key: timer_callback1
+    - pkg: test_pkg1
+      executable: test_controller
+      callback_groups:
+        cbg1: MutuallyExclusiveCallbackGroup
+        cbg2: ReentrantCallbackGroup
+      publishers:
+        - ros_parameter: pub_ctrl_settings1
+          key: pub1
+          topic: /test/controller/pub1
+          msg_type: TestMsg
+          history_depth: 10
+          callback_group: cbg1
+          non_obelisk: False
+      subscribers:
+        - ros_parameter: sub_ctrl_settings1
+          key: sub1
+          topic: /test/controller/sub1
+          msg_type: TestMsg
+          history_depth: 5
+          callback_key: sub_callback1
+          callback_group: cbg2
+          non_obelisk: False
+      timers:
+        - ros_parameter: timer_ctrl_settings1
+          key: timer1
+          timer_period_sec: 0.1
+          callback_group: cbg1
+          callback_key: timer_callback1
   estimation:
-    pkg: test_pkg2
-    executable: test_estimator
-    callback_groups:
-      cbg1: ReentrantCallbackGroup
+    - pkg: test_pkg2
+      executable: test_estimator
+      callback_groups:
+        cbg1: ReentrantCallbackGroup
   robot:
-    pkg: test_pkg3
-    executable: test_robot
-    callback_groups:
-      cbg1: MutuallyExclusiveCallbackGroup
+    - pkg: test_pkg3
+      executable: test_robot
+      callback_groups:
+        cbg1: MutuallyExclusiveCallbackGroup
   sensing:
     - pkg: test_pkg4
       executable: test_sensor1

--- a/tests/tests_python/tests_core/test_utils/test_launch_utils.py
+++ b/tests/tests_python/tests_core/test_utils/test_launch_utils.py
@@ -17,53 +17,59 @@ def test_config() -> Dict[str, Any]:
     """Fixture to provide test configuration data."""
     return {
         "onboard": {
-            "control": {
-                "pkg": "test_pkg1",
-                "executable": "test_controller",
-                "callback_groups": {"cbg1": "MutuallyExclusiveCallbackGroup", "cbg2": "ReentrantCallbackGroup"},
-                "publishers": [
-                    {
-                        "ros_parameter": "pub_ctrl_settings1",
-                        "key": "pub1",
-                        "topic": "/test/controller/pub1",
-                        "msg_type": "TestMsg",
-                        "history_depth": 10,
-                        "callback_group": "cbg1",
-                        "non_obelisk": False,
-                    }
-                ],
-                "subscribers": [
-                    {
-                        "ros_parameter": "sub_ctrl_settings1",
-                        "key": "sub1",
-                        "topic": "/test/controller/sub1",
-                        "msg_type": "TestMsg",
-                        "history_depth": 5,
-                        "callback_key": "sub_callback1",
-                        "callback_group": "cbg2",
-                        "non_obelisk": False,
-                    }
-                ],
-                "timers": [
-                    {
-                        "ros_parameter": "timer_ctrl_settings1",
-                        "key": "timer1",
-                        "timer_period_sec": 0.1,
-                        "callback_group": "cbg1",
-                        "callback_key": "timer_callback1",
-                    }
-                ],
-            },
-            "estimation": {
-                "pkg": "test_pkg2",
-                "executable": "test_estimator",
-                "callback_groups": {"cbg1": "ReentrantCallbackGroup"},
-            },
-            "robot": {
-                "pkg": "test_pkg3",
-                "executable": "test_robot",
-                "callback_groups": {"cbg1": "MutuallyExclusiveCallbackGroup"},
-            },
+            "control": [
+                {
+                    "pkg": "test_pkg1",
+                    "executable": "test_controller",
+                    "callback_groups": {"cbg1": "MutuallyExclusiveCallbackGroup", "cbg2": "ReentrantCallbackGroup"},
+                    "publishers": [
+                        {
+                            "ros_parameter": "pub_ctrl_settings1",
+                            "key": "pub1",
+                            "topic": "/test/controller/pub1",
+                            "msg_type": "TestMsg",
+                            "history_depth": 10,
+                            "callback_group": "cbg1",
+                            "non_obelisk": False,
+                        }
+                    ],
+                    "subscribers": [
+                        {
+                            "ros_parameter": "sub_ctrl_settings1",
+                            "key": "sub1",
+                            "topic": "/test/controller/sub1",
+                            "msg_type": "TestMsg",
+                            "history_depth": 5,
+                            "callback_key": "sub_callback1",
+                            "callback_group": "cbg2",
+                            "non_obelisk": False,
+                        }
+                    ],
+                    "timers": [
+                        {
+                            "ros_parameter": "timer_ctrl_settings1",
+                            "key": "timer1",
+                            "timer_period_sec": 0.1,
+                            "callback_group": "cbg1",
+                            "callback_key": "timer_callback1",
+                        }
+                    ],
+                }
+            ],
+            "estimation": [
+                {
+                    "pkg": "test_pkg2",
+                    "executable": "test_estimator",
+                    "callback_groups": {"cbg1": "ReentrantCallbackGroup"},
+                }
+            ],
+            "robot": [
+                {
+                    "pkg": "test_pkg3",
+                    "executable": "test_robot",
+                    "callback_groups": {"cbg1": "MutuallyExclusiveCallbackGroup"},
+                }
+            ],
             "sensing": [
                 {
                     "pkg": "test_pkg4",
@@ -134,7 +140,7 @@ def test_get_component_settings_subdict(test_config: Dict[str, Any]) -> None:
     Args:
         test_config: Test configuration fixture.
     """
-    node_settings = test_config["onboard"]["control"]
+    node_settings = test_config["onboard"]["control"][0]
 
     # Test publishers
     pub_settings = get_component_settings_subdict(node_settings, "publishers")
@@ -170,7 +176,7 @@ def test_get_parameters_dict(test_config: Dict[str, Any]) -> None:
     Args:
         test_config: Test configuration fixture.
     """
-    node_settings = test_config["onboard"]["control"]
+    node_settings = test_config["onboard"]["control"][0]
     parameters_dict = get_parameters_dict(node_settings)
 
     expected_dict = {


### PR DESCRIPTION
[WARNING] don't merge this before #60.

Allows multinode configuration. New breaking change: in yaml files, the node settings under ALL node type headings (i.e., `control`, `estimation`, `robot`, and `sensing`) must be in yaml lists, even if there is only a single node!