### PR TITLE
Mujoco Sim Camera Render (Python)

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -29,6 +29,7 @@ services:
       - $HOME/.Xauthority:$HOME/.Xauthority:rw
       - $HOME/.bashrc:$HOME/.bashrc
       - /etc/sysctl.d/60-cyclonedds.conf:/etc/sysctl.d/60-cyclonedds.conf
+      - /usr/share/glvnd/egl_vendor.d/10_nvidia.json:/usr/share/glvnd/egl_vendor.d/10_nvidia.json
     ports:
       - 7007:7007
     privileged: true

--- a/models/dummy/dummy.xml
+++ b/models/dummy/dummy.xml
@@ -26,6 +26,9 @@
                 <joint name="joint1" type="hinge" pos="0 0 0" axis="0 1 0" range="-1.5708 1.5708"/>
             </body>
         </body>
+
+        <!-- Cameras -->
+        <camera name="cam1" pos="0.5 0 0.25" mode="fixed" fovy="70" resolution="128 128" quat="1 0 0 0" />
     </worldbody>
 
     <!-- Actuators -->

--- a/models/dummy/dummy.xml
+++ b/models/dummy/dummy.xml
@@ -6,6 +6,7 @@
 
     <visual>
         <map znear="0.01" zfar="50"/>
+        <global azimuth="180" elevation="-30" offheight="256" offwidth="256" fovy="70"/>
     </visual>
 
     <!-- Must collision filter second link from static first link -->

--- a/obelisk/python/obelisk_py/core/sim/mujoco.py
+++ b/obelisk/python/obelisk_py/core/sim/mujoco.py
@@ -15,6 +15,7 @@ from rclpy.publisher import Publisher
 
 from obelisk_py.core.obelisk_typing import ObeliskSensorMsg, is_in_bound
 from obelisk_py.core.robot import ObeliskSimRobot
+from obelisk_py.core.utils.msg import np_to_multiarray
 
 
 class ObeliskMujocoRobot(ObeliskSimRobot):
@@ -24,6 +25,7 @@ class ObeliskMujocoRobot(ObeliskSimRobot):
         """Initialize the mujoco simulator."""
         super().__init__(node_name)
         self.declare_parameter("mujoco_setting", rclpy.Parameter.Type.STRING)
+        self.renderer = None
 
     def _get_msg_type_from_mj_sensor_type(self, sensor_type: str) -> Type[ObeliskSensorMsg]:
         """Get the message type from the Mujoco sensor type.
@@ -43,6 +45,9 @@ class ObeliskMujocoRobot(ObeliskSimRobot):
         if sensor_type == "jointpos":
             assert is_in_bound(osm.JointEncoders, ObeliskSensorMsg)
             return osm.JointEncoders  # type: ignore
+        elif sensor_type == "camera":
+            assert is_in_bound(osm.MujocoImage, ObeliskSensorMsg)
+            return osm.MujocoImage  # type: ignore
         else:
             raise NotImplementedError(f"Sensor type {sensor_type} not supported! Check your spelling or open a PR.")
 
@@ -66,15 +71,37 @@ class ObeliskMujocoRobot(ObeliskSimRobot):
         Returns:
             The timer callback function.
         """
+        if msg_type in [osm.JointEncoders]:
 
-        def timer_callback() -> None:
-            """Timer callback for the sensor."""
-            msg = msg_type()
-            y = []
-            for sensor_name in sensor_names:
-                y.append(self.mj_data.sensor(sensor_name).data)
-            msg.y = list(np.concatenate(y))  # like we assume all ObeliskControlMsg objs have a u field, sensors have y
-            pub_sensor.publish(msg)
+            def timer_callback() -> None:
+                """Timer callback for the sensor."""
+                msg = msg_type()
+                y = []
+                for sensor_name in sensor_names:
+                    y.append(self.mj_data.sensor(sensor_name).data)
+                msg.y = list(np.concatenate(y))  # assume all ObeliskSensorMsg objs have a y field
+                pub_sensor.publish(msg)
+
+        elif msg_type == osm.MujocoImage:
+
+            def timer_callback() -> None:
+                """Timer callback for the sensor."""
+                images = []
+                for cam_name in sensor_names:
+                    try:
+                        cam_id = self.mj_model.cam(cam_name).id
+                        width, height = self.mj_model.cam_resolution[cam_id]
+                        with mujoco.Renderer(self.mj_model, height, width) as renderer:
+                            renderer.update_scene(self.mj_data, camera=cam_name)
+                            image = renderer.render()
+                            images.append(image)
+                    except KeyError as e:
+                        self.get_logger().error(f"Could not find camera {cam_name} in the model!")
+                        raise e
+
+                msg = msg_type()
+                msg.y = np_to_multiarray(np.stack(images))  # (num_images, height, width, channels), dtype: uint8
+                pub_sensor.publish(msg)
 
         return timer_callback
 
@@ -106,6 +133,7 @@ class ObeliskMujocoRobot(ObeliskSimRobot):
             model_xml_path = self.model_xml_path
         self.mj_model = MjModel.from_xml_path(model_xml_path)
         self.mj_data = MjData(self.mj_model)
+        mujoco.mj_forward(self.mj_model, self.mj_data)  # initialize data
 
         # set the configuration parameters for non-sensor fields
         self.n_u = int(config_dict["n_u"])
@@ -160,6 +188,7 @@ class ObeliskMujocoRobot(ObeliskSimRobot):
                     callback=timer_callback,
                     callback_group=cbg,
                 )
+                self.get_logger().info(f"Created sensor publisher and timer for topic {topic} with dt {dt}.")
                 timer_sensor.cancel()
                 self.obk_publishers[f"sensor_group_{i}"] = pub_sensor
                 self.obk_timers[f"sensor_group_{i}"] = timer_sensor

--- a/obelisk/python/obelisk_py/core/sim/mujoco.py
+++ b/obelisk/python/obelisk_py/core/sim/mujoco.py
@@ -103,6 +103,9 @@ class ObeliskMujocoRobot(ObeliskSimRobot):
                 msg.y = np_to_multiarray(np.stack(images))  # (num_images, height, width, channels), dtype: uint8
                 pub_sensor.publish(msg)
 
+        else:
+            raise NotImplementedError(f"Message type {msg_type} not supported! Check your spelling or open a PR.")
+
         return timer_callback
 
     def on_configure(self, state: LifecycleState) -> TransitionCallbackReturn:  # noqa: PLR0915
@@ -133,7 +136,7 @@ class ObeliskMujocoRobot(ObeliskSimRobot):
             model_xml_path = self.model_xml_path
         self.mj_model = MjModel.from_xml_path(model_xml_path)
         self.mj_data = MjData(self.mj_model)
-        mujoco.mj_forward(self.mj_model, self.mj_data)  # initialize data
+        mujoco.mj_forward(self.mj_model, self.mj_data)  # type: ignore
 
         # set the configuration parameters for non-sensor fields
         self.n_u = int(config_dict["n_u"])

--- a/obelisk/python/obelisk_py/core/sim/mujoco.py
+++ b/obelisk/python/obelisk_py/core/sim/mujoco.py
@@ -25,7 +25,6 @@ class ObeliskMujocoRobot(ObeliskSimRobot):
         """Initialize the mujoco simulator."""
         super().__init__(node_name)
         self.declare_parameter("mujoco_setting", rclpy.Parameter.Type.STRING)
-        self.renderer = None
 
     def _get_msg_type_from_mj_sensor_type(self, sensor_type: str) -> Type[ObeliskSensorMsg]:
         """Get the message type from the Mujoco sensor type.

--- a/obelisk/python/obelisk_py/core/utils/msg.py
+++ b/obelisk/python/obelisk_py/core/utils/msg.py
@@ -1,0 +1,53 @@
+import numpy as np
+from obelisk_std_msgs.msg import FloatMultiArray
+from std_msgs.msg import MultiArrayDimension, MultiArrayLayout
+
+
+def multiarray_to_np(msg: FloatMultiArray) -> np.ndarray:
+    """Convert FloatMultiArray message to numpy array.
+
+    multiarray(i,j,k,...) = data[data_offset + dim_stride[0]*i + dim_stride[1]*j + dim_stride[2]*k + ...]
+
+    Parameters:
+        msg: FloatMultiArray message.
+
+    Returns:
+        Numpy array.
+    """
+    flat_data = np.array(msg.data, dtype=np.float64)
+    if msg.layout.data_offset:
+        flat_data = flat_data[msg.layout.data_offset :]
+
+    shape = [dim.size for dim in msg.layout.dim]
+    strides = [dim.stride * flat_data.itemsize for dim in msg.layout.dim]
+    return np.lib.stride_tricks.as_strided(flat_data, shape=shape, strides=strides)
+
+
+def np_to_multiarray(arr: np.ndarray) -> FloatMultiArray:
+    """Convert numpy array to FloatMultiArray message.
+
+    multiarray(i,j,k,...) = data[data_offset + dim_stride[0]*i + dim_stride[1]*j + dim_stride[2]*k + ...]
+
+    Parameters:
+        arr: Numpy array.
+
+    Returns:
+        FloatMultiArray message.
+    """
+    msg = FloatMultiArray()
+    flat_data = arr.ravel()
+    msg.data = flat_data.tolist()
+    msg.layout = MultiArrayLayout()
+
+    dimensions = []
+    for i, (size, stride) in enumerate(zip(arr.shape, arr.strides)):
+        dim = MultiArrayDimension()
+        dim.size = size
+        dim.stride = stride // arr.itemsize  # convert byte strides to element strides
+        dim.label = f"dim_{i}"
+        dimensions.append(dim)
+
+    msg.layout.dim = dimensions
+    msg.layout.data_offset = 0
+
+    return msg

--- a/obelisk_ws/src/obelisk_msgs/obelisk_sensor_msgs/CMakeLists.txt
+++ b/obelisk_ws/src/obelisk_msgs/obelisk_sensor_msgs/CMakeLists.txt
@@ -12,12 +12,15 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 find_package(std_msgs REQUIRED)
+find_package(obelisk_std_msgs REQUIRED)
 
 rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/JointEncoders.msg"
   "msg/TrueSimState.msg"
+  "msg/MujocoImage.msg"
   DEPENDENCIES
   std_msgs
+  obelisk_std_msgs
 )
 
 set(THIS_PACKAGE_INCLUDE_DEPENDS

--- a/obelisk_ws/src/obelisk_msgs/obelisk_sensor_msgs/msg/MujocoImage.msg
+++ b/obelisk_ws/src/obelisk_msgs/obelisk_sensor_msgs/msg/MujocoImage.msg
@@ -1,0 +1,2 @@
+string MESSAGE_NAME="MujocoImage"
+obelisk_std_msgs/UInt8MultiArray y

--- a/obelisk_ws/src/obelisk_msgs/obelisk_sensor_msgs/package.xml
+++ b/obelisk_ws/src/obelisk_msgs/obelisk_sensor_msgs/package.xml
@@ -9,6 +9,7 @@
   <author email="alberthli@caltech.edu">Albert Li</author>
 
   <depend>std_msgs</depend>
+  <depend>obelisk_std_msgs</depend>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>rosidl_default_generators</buildtool_depend>

--- a/obelisk_ws/src/obelisk_msgs/obelisk_std_msgs/CMakeLists.txt
+++ b/obelisk_ws/src/obelisk_msgs/obelisk_std_msgs/CMakeLists.txt
@@ -1,0 +1,30 @@
+cmake_minimum_required(VERSION 3.16)
+
+project(obelisk_std_msgs)
+
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+find_package(std_msgs REQUIRED)
+
+rosidl_generate_interfaces(${PROJECT_NAME}
+  "msg/FloatMultiArray.msg"
+  DEPENDENCIES
+  std_msgs
+)
+
+set(THIS_PACKAGE_INCLUDE_DEPENDS
+  ament_cmake
+  std_msgs
+  rosidl_default_generators
+)
+include_directories(${THIS_PACKAGE_INCLUDE_DEPENDS})
+
+ament_export_dependencies(rosidl_default_runtime)
+ament_package()

--- a/obelisk_ws/src/obelisk_msgs/obelisk_std_msgs/CMakeLists.txt
+++ b/obelisk_ws/src/obelisk_msgs/obelisk_std_msgs/CMakeLists.txt
@@ -15,6 +15,7 @@ find_package(std_msgs REQUIRED)
 
 rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/FloatMultiArray.msg"
+  "msg/UInt8MultiArray.msg"
   DEPENDENCIES
   std_msgs
 )

--- a/obelisk_ws/src/obelisk_msgs/obelisk_std_msgs/msg/FloatMultiArray.msg
+++ b/obelisk_ws/src/obelisk_msgs/obelisk_std_msgs/msg/FloatMultiArray.msg
@@ -6,6 +6,5 @@
 
 string MESSAGE_NAME="FloatMultiArray"
 
-std_msgs/MultiArrayDimension[] dim
-uint32 data_offset
+std_msgs/MultiArrayLayout layout
 float64[] data

--- a/obelisk_ws/src/obelisk_msgs/obelisk_std_msgs/msg/FloatMultiArray.msg
+++ b/obelisk_ws/src/obelisk_msgs/obelisk_std_msgs/msg/FloatMultiArray.msg
@@ -1,0 +1,11 @@
+# This message type is meant to be a "fixed" version of the deprecated Float64MultiArray message type
+# Original message type: http://docs.ros.org/en/melodic/api/std_msgs/html/msg/Float64MultiArray.html
+# Github issue discussing striding: https://github.com/ros/std_msgs/issues/8
+# We follow the striding convention discussed in the above issue:
+# multiarray(i,j,k) = data[data_offset + dim_stride[0]*i + dim_stride[1]*j + dim_stride[2]*k]
+
+string MESSAGE_NAME="FloatMultiArray"
+
+std_msgs/MultiArrayDimension[] dim
+uint32 data_offset
+float64[] data

--- a/obelisk_ws/src/obelisk_msgs/obelisk_std_msgs/msg/UInt8MultiArray.msg
+++ b/obelisk_ws/src/obelisk_msgs/obelisk_std_msgs/msg/UInt8MultiArray.msg
@@ -1,0 +1,10 @@
+# This message type is meant to be a "fixed" version of the deprecated Float64MultiArray message type
+# Original message type: http://docs.ros.org/en/melodic/api/std_msgs/html/msg/Float64MultiArray.html
+# Github issue discussing striding: https://github.com/ros/std_msgs/issues/8
+# We follow the striding convention discussed in the above issue:
+# multiarray(i,j,k) = data[data_offset + dim_stride[0]*i + dim_stride[1]*j + dim_stride[2]*k]
+
+string MESSAGE_NAME="UInt8MultiArray"
+
+std_msgs/MultiArrayLayout layout
+uint8[] data

--- a/obelisk_ws/src/obelisk_msgs/obelisk_std_msgs/package.xml
+++ b/obelisk_ws/src/obelisk_msgs/obelisk_std_msgs/package.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>obelisk_std_msgs</name>
+  <version>0.0.1</version>
+  <description>Obelisk messages that support standard data structures.</description>
+  <maintainer email="alberthli@caltech.edu">Albert Li</maintainer>
+  <license>Apache License 2.0</license>
+  <author email="alberthli@caltech.edu">Albert Li</author>
+
+  <depend>std_msgs</depend>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>rosidl_default_generators</buildtool_depend>
+  <exec_depend>rosidl_default_runtime</exec_depend>
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/obelisk_ws/src/obelisk_ros/config/dummy_py.yaml
+++ b/obelisk_ws/src/obelisk_ros/config/dummy_py.yaml
@@ -74,3 +74,8 @@ onboard:
             sensor_type: jointpos
             sensor_names:
             - sensor_joint1
+          - topic: /obelisk/dummy/cam1
+            dt: 0.05
+            sensor_type: camera
+            sensor_names:
+            - cam1

--- a/pixi.toml
+++ b/pixi.toml
@@ -170,7 +170,7 @@ build = { features = ["cuda121", "build"] }
 # builds in the obelisk_ws directory only if src has changes
 ros-build = { cmd="colcon build --symlink-install --parallel-workers $(nproc)", cwd="obelisk_ws" }
 source-obelisk = { cmd="bash source_obelisk.sh", cwd="scripts", depends-on=["ros-build"], env={ NOOB="true", GLOBAL="false" } }
-messages-build = { cmd="colcon build --symlink-install --packages-select obelisk_control_msgs obelisk_estimator_msgs obelisk_sensor_msgs", cwd="obelisk_ws" }
+messages-build = { cmd="colcon build --symlink-install --packages-select obelisk_control_msgs obelisk_estimator_msgs obelisk_sensor_msgs obelisk_std_msgs", cwd="obelisk_ws" }
 
 # run the core tests
 cpp-test-node = { cmd = "obelisk/cpp/build/tests/NodeTest", depends-on = ["cpp-build"] }

--- a/pixi.toml
+++ b/pixi.toml
@@ -14,7 +14,7 @@ platforms = ["linux-64"]
 
 [activation]
 scripts = ["obelisk_ws/install/setup.sh"]
-
+env = { RMW_IMPLEMENTATION="rmw_cyclonedds_cpp" }
 
 # ############ #
 # FEATURE SETS #

--- a/tests/tests_python/tests_core/test_utils/test_msg.py
+++ b/tests/tests_python/tests_core/test_utils/test_msg.py
@@ -1,0 +1,13 @@
+import numpy as np
+from obelisk_std_msgs.msg import FloatMultiArray
+
+from obelisk_py.core.utils.msg import multiarray_to_np, np_to_multiarray
+
+
+def test_conversion() -> None:
+    """Test the conversion between numpy array and FloatMultiArray."""
+    arr = np.random.rand(3, 4, 5)
+    msg = np_to_multiarray(arr)
+    assert isinstance(msg, FloatMultiArray)
+    arr_recovered = multiarray_to_np(msg)
+    assert np.allclose(arr, arr_recovered)


### PR DESCRIPTION
Adds cameras as available sensors from the Mujoco Sim robot + features required to support this.

- New Obelisk message package and type: `FloatMultiArray` in `obelisk_std_msgs`. This differs from the deprecated `Float64MultiArray` in ROS2's `std_msgs` library, as it implements the striding discussed in this issue: https://github.com/ros/std_msgs/issues/8. This message allows us to easily send multi-dimensional arrays as ROS messages, and we can convert to `numpy` arrays using provided utils.
- Added a `MujocoImage` message type, publish this out of the timer/pub pair from the mujoco sim robot based on configuration in the yaml file

TODOs:
- figure out why the renderer is being slow in python
- figure out how to check whether GPU rendering is being used on vulcan