### PR TITLE
Update the viz example to work again

### DIFF
--- a/obelisk_ws/src/obelisk_ros/config/dummy_cpp_viz.yaml
+++ b/obelisk_ws/src/obelisk_ros/config/dummy_cpp_viz.yaml
@@ -3,6 +3,7 @@ onboard:
   control:
     - pkg: obelisk_control_cpp
       executable: example_position_setpoint_controller
+      params_path: /obelisk_ws/src/obelisk_ros/config/dummy_params.txt
       # callback_groups:
       publishers:
         - ros_parameter: pub_ctrl_setting


### PR DESCRIPTION
Viz example was missing a line for configuring the amplitude to demonstrate file params.