### PR TITLE
Configure Additional Declared ROS Parameters in YAML File

### DIFF
--- a/obelisk/cpp/zoo/include/position_setpoint_controller.h
+++ b/obelisk/cpp/zoo/include/position_setpoint_controller.h
@@ -13,6 +13,7 @@ class PositionSetpointController : public obelisk::ObeliskController<obelisk_con
     PositionSetpointController(const std::string& name)
         : obelisk::ObeliskController<obelisk_control_msgs::msg::PositionSetpoint,
                                      obelisk_estimator_msgs::msg::EstimatedState>(name) {
+        // example of params_path
         std::string file_string = this->get_parameter("params_path").as_string();
         std::string obk_root    = std::getenv("OBELISK_ROOT");
         std::filesystem::path file_path(obk_root);
@@ -28,6 +29,12 @@ class PositionSetpointController : public obelisk::ObeliskController<obelisk_con
         std::string contents;
         params_file >> contents;
         amplitude_ = std::stof(contents);
+
+        // example of setting other configurable params in the node
+        this->declare_parameter<std::string>("test_param", "default_value");
+        std::string test_param_value_;
+        this->get_parameter("test_param", test_param_value_);
+        RCLCPP_INFO_STREAM(this->get_logger(), "test_param: " << test_param_value_);
     }
 
   protected:

--- a/obelisk/cpp/zoo/include/position_setpoint_controller.h
+++ b/obelisk/cpp/zoo/include/position_setpoint_controller.h
@@ -32,9 +32,9 @@ class PositionSetpointController : public obelisk::ObeliskController<obelisk_con
 
         // example of setting other configurable params in the node
         this->declare_parameter<std::string>("test_param", "default_value");
-        std::string test_param_value_;
-        this->get_parameter("test_param", test_param_value_);
-        RCLCPP_INFO_STREAM(this->get_logger(), "test_param: " << test_param_value_);
+        std::string test_param_value;
+        this->get_parameter("test_param", test_param_value);
+        RCLCPP_INFO_STREAM(this->get_logger(), "test_param: " << test_param_value);
     }
 
   protected:

--- a/obelisk/python/obelisk_py/core/utils/launch_utils.py
+++ b/obelisk/python/obelisk_py/core/utils/launch_utils.py
@@ -161,6 +161,10 @@ def get_parameters_dict(node_settings: Dict) -> Dict:
     parameters_dict = (
         {"callback_group_settings": callback_group_settings} if callback_group_settings is not None else {}
     )
+    if "params_path" in node_settings:
+        parameters_dict["params_path"] = node_settings["params_path"]
+    if "params" in node_settings:
+        parameters_dict.update(node_settings["params"])
     parameters_dict.update(pub_settings_dict)
     parameters_dict.update(sub_settings_dict)
     parameters_dict.update(timer_settings_dict)
@@ -189,10 +193,6 @@ def get_launch_actions_from_node_settings(
         package = node_settings["pkg"]
         executable = node_settings["executable"]
         parameters_dict = get_parameters_dict(node_settings)
-
-        if "params_path" in node_settings:
-            parameters_dict["params_path"] = node_settings["params_path"]
-
         launch_actions = []
         component_node = LifecycleNode(
             namespace="",

--- a/obelisk/python/obelisk_py/zoo/control/example/example_position_setpoint_controller.py
+++ b/obelisk/python/obelisk_py/zoo/control/example/example_position_setpoint_controller.py
@@ -12,6 +12,8 @@ class ExamplePositionSetpointController(ObeliskController):
     def __init__(self, node_name: str = "example_position_setpoint_controller") -> None:
         """Initialize the example position setpoint controller."""
         super().__init__(node_name)
+        self.declare_parameter("test_param", "default_value")
+        self.get_logger().info(f"test_param: {self.get_parameter('test_param').get_parameter_value().string_value}")
 
     def on_configure(self, state: LifecycleState) -> TransitionCallbackReturn:
         """Configure the controller."""

--- a/obelisk_ws/src/obelisk_ros/config/dummy_cpp.yaml
+++ b/obelisk_ws/src/obelisk_ros/config/dummy_cpp.yaml
@@ -5,6 +5,8 @@ onboard:
       executable: example_position_setpoint_controller
       params_path: /obelisk_ws/src/obelisk_ros/config/dummy_params.txt
       # callback_groups:
+      params:
+        test_param: value_configured_in_yaml
       publishers:
         - ros_parameter: pub_ctrl_setting
           # key: pub1

--- a/obelisk_ws/src/obelisk_ros/config/dummy_py.yaml
+++ b/obelisk_ws/src/obelisk_ros/config/dummy_py.yaml
@@ -4,6 +4,8 @@ onboard:
     - pkg: obelisk_control_py
       executable: example_position_setpoint_controller
       # callback_groups:
+      params:
+        test_param: value_configured_in_yaml
       publishers:
         - ros_parameter: pub_ctrl_setting
           topic: /obelisk/dummy/ctrl


### PR DESCRIPTION
Sometimes, we may want to expose additional ROS parameters in an ObeliskNode. It may be convenient to set these directly in the master yaml file rather than supplying a path to some additional configuration file, especially if there are only a few parameters. This PR allows the end user to configure these parameters.