### PR TITLE
Added ability to give Mujoco initial conditions from the keyframes.

### DIFF
--- a/obelisk/python/obelisk_py/core/sim/mujoco.py
+++ b/obelisk/python/obelisk_py/core/sim/mujoco.py
@@ -9,7 +9,7 @@ import numpy as np
 import obelisk_sensor_msgs.msg as osm
 import rclpy
 from ament_index_python.packages import get_package_share_directory
-from mujoco import MjData, MjModel, mj_forward, mj_name2id, mj_step  # type: ignore
+from mujoco import MjData, MjModel, mj_forward, mj_name2id, mj_step, mju_copy  # type: ignore
 from rclpy.callback_groups import ReentrantCallbackGroup
 from rclpy.lifecycle import LifecycleState, TransitionCallbackReturn
 from rclpy.publisher import Publisher
@@ -428,17 +428,11 @@ class ObeliskMujocoRobot(ObeliskSimRobot):
             potential_keyframe = self.mj_model.key(i).name
             if potential_keyframe == self.get_parameter("ic_keyframe").get_parameter_value().string_value:
                 self.get_logger().info(f"Setting initial condition to keyframe: {potential_keyframe}")
-                mujoco.mju_copy(
-                    self.mj_data.qpos, self.mj_model.key_qpos[i * self.mj_model.nq : (i + 1) * self.mj_model.nq]
-                )
-                mujoco.mju_copy(
-                    self.mj_data.qvel, self.mj_model.key_qvel[i * self.mj_model.nv : (i + 1) * self.mj_model.nv]
-                )
+                mju_copy(self.mj_data.qpos, self.mj_model.key_qpos[i * self.mj_model.nq : (i + 1) * self.mj_model.nq])
+                mju_copy(self.mj_data.qvel, self.mj_model.key_qvel[i * self.mj_model.nv : (i + 1) * self.mj_model.nv])
                 self.mj_data.time = self.mj_model.key_time[i]
 
-                mujoco.mju_copy(
-                    self.mj_data.ctrl, self.mj_model.key_ctrl[i * self.mj_model.nu : (i + 1) * self.mj_model.nu]
-                )
+                mju_copy(self.mj_data.ctrl, self.mj_model.key_ctrl[i * self.mj_model.nu : (i + 1) * self.mj_model.nu])
 
         with mujoco.viewer.launch_passive(self.mj_model, self.mj_data) as viewer:
             while viewer.is_running() and self.is_sim_running.value:

--- a/obelisk_ws/src/obelisk_ros/config/dummy_cpp.yaml
+++ b/obelisk_ws/src/obelisk_ros/config/dummy_cpp.yaml
@@ -62,6 +62,8 @@ onboard:
     - is_simulated: True
       pkg: obelisk_sim_cpp
       executable: obelisk_mujoco_robot
+      params:
+        ic_keyframe: ic
       # callback_groups:
       # publishers:
       subscribers:

--- a/obelisk_ws/src/obelisk_ros/config/dummy_py.yaml
+++ b/obelisk_ws/src/obelisk_ros/config/dummy_py.yaml
@@ -54,6 +54,8 @@ onboard:
     - is_simulated: True
       pkg: obelisk_sim_py
       executable: obelisk_mujoco_robot
+      params:
+        ic_keyframe: other
       # callback_groups:
       # publishers:
       subscribers:

--- a/obelisk_ws/src/robots/dummy_bot/mujoco/dummy.xml
+++ b/obelisk_ws/src/robots/dummy_bot/mujoco/dummy.xml
@@ -50,4 +50,9 @@
         <framepos name="tip_pos_sensor" objtype="site" objname="tip"/>
         <framequat name="tip_orientation_sensor" objtype="site" objname="tip"/>
     </sensor>
+
+    <keyframe>
+        <key name="other" qpos="-1" ctrl="-1" time="1"/>
+        <key name="ic" qpos="1" ctrl="1" time="3" />
+    </keyframe>
 </mujoco>


### PR DESCRIPTION
Added ability to start simulation from Mujoco key frames.

Note that key frame are automatically checked for compatibility by Mujoco so there is no need to verify sizes.

Currently only support `qpos`, `qvel`, `ctrl`, and `time`.