### PR TITLE
Patch `OBELISK_BUILD_X` vars for local install

### DIFF
--- a/obelisk/cpp/zoo/CMakeLists.txt
+++ b/obelisk/cpp/zoo/CMakeLists.txt
@@ -25,7 +25,8 @@ target_include_directories(Zoo INTERFACE include)
 
 # conditionally add leap subdirectory if OBELISK_BUILD_LEAP is set
 message(STATUS "OBELISK_BUILD_LEAP: ${OBELISK_BUILD_LEAP}")
-if((DEFINED OBELISK_BUILD_LEAP) OR (DEFINED ENV{OBELISK_BUILD_LEAP}))
+if((DEFINED OBELISK_BUILD_LEAP AND OBELISK_BUILD_LEAP STREQUAL "true") OR
+   (DEFINED ENV{OBELISK_BUILD_LEAP} AND ENV{OBELISK_BUILD_LEAP} STREQUAL "true"))
   message(STATUS "Configuring Leap Hand Interface")
   add_subdirectory(hardware/robots/leap)
   target_include_directories(Zoo INTERFACE hardware/robots/leap)
@@ -35,7 +36,8 @@ endif()
 
 # conditionally add zed subdirectory if OBELISK_BUILD_ZED is set
 message(STATUS "OBELISK_BUILD_ZED: ${OBELISK_BUILD_ZED}")
-if((DEFINED OBELISK_BUILD_ZED) OR (DEFINED ENV{OBELISK_BUILD_ZED}))
+if((DEFINED OBELISK_BUILD_ZED AND OBELISK_BUILD_ZED STREQUAL "true") OR
+   (DEFINED ENV{OBELISK_BUILD_ZED} AND ENV{OBELISK_BUILD_ZED} STREQUAL "true"))
   message(STATUS "Configuring Zed2 Sensors")
   add_subdirectory(hardware/sensing/zed)
   target_include_directories(Zoo INTERFACE hardware/sensing/zed)

--- a/scripts/user_setup.sh
+++ b/scripts/user_setup.sh
@@ -72,10 +72,14 @@ fi'
     if [ "$leap" = true ]; then
         OBELISK_BUILD_OPTIONS+="--leap "
         OBELISK_BUILD_LEAP=true
+    else
+        OBELISK_BUILD_LEAP=false
     fi
     if [ "$zed" = true ]; then
         OBELISK_BUILD_OPTIONS+="--zed "
         OBELISK_BUILD_ZED=true
+    else
+        OBELISK_BUILD_ZED=false
     fi
 
     obk_aliases=$(cat << EOF


### PR DESCRIPTION
There seems to be a bug where leap or zed ros packages are built in local downstream installs of obelisk even when those flags are not passed to the setup script. This PR is an attempt to fix it.