### PR TITLE
Remove Obelisk message requirements in python

### DIFF
--- a/obelisk/python/obelisk_py/core/control.py
+++ b/obelisk/python/obelisk_py/core/control.py
@@ -1,7 +1,6 @@
 from abc import ABC, abstractmethod
 
 from obelisk_py.core.node import ObeliskNode
-from obelisk_py.core.obelisk_typing import ObeliskControlMsg, ObeliskEstimatorMsg
 
 
 class ObeliskController(ABC, ObeliskNode):
@@ -38,7 +37,7 @@ class ObeliskController(ABC, ObeliskNode):
         )
 
     @abstractmethod
-    def update_x_hat(self, x_hat_msg: ObeliskEstimatorMsg) -> None:
+    def update_x_hat(self, x_hat_msg) -> None:
         """Update the state estimate.
 
         Parameters:
@@ -46,7 +45,7 @@ class ObeliskController(ABC, ObeliskNode):
         """
 
     @abstractmethod
-    def compute_control(self) -> ObeliskControlMsg:
+    def compute_control(self):
         """Compute the control signal.
 
         This is the control timer callback and is expected to call 'publisher_ctrl' internally. Note that the control

--- a/obelisk/python/obelisk_py/core/estimation.py
+++ b/obelisk/python/obelisk_py/core/estimation.py
@@ -1,11 +1,9 @@
 from abc import ABC, abstractmethod
-from typing import Union
 
 import obelisk_sensor_msgs.msg as osm
 from rclpy.lifecycle.node import LifecycleState, TransitionCallbackReturn
 
 from obelisk_py.core.node import ObeliskNode
-from obelisk_py.core.obelisk_typing import ObeliskEstimatorMsg, ObeliskSensorMsg
 from obelisk_py.core.utils.internal import get_classes_in_module
 
 
@@ -65,7 +63,7 @@ class ObeliskEstimator(ABC, ObeliskNode):
         return TransitionCallbackReturn.SUCCESS
 
     @abstractmethod
-    def compute_state_estimate(self) -> Union[ObeliskEstimatorMsg, ObeliskSensorMsg]:
+    def compute_state_estimate(self):
         """Compute the state estimate.
 
         This is the state estimate timer callback and is expected to call 'publisher_est' internally. Note that the

--- a/obelisk/python/obelisk_py/core/obelisk_typing.py
+++ b/obelisk/python/obelisk_py/core/obelisk_typing.py
@@ -3,7 +3,6 @@ from typing import List, Type, TypeVar, Union, get_args, get_origin
 import obelisk_control_msgs.msg as ocm
 import obelisk_estimator_msgs.msg as oem
 import obelisk_sensor_msgs.msg as osm
-from rcl_interfaces.msg import ParameterEvent
 
 from obelisk_py.core.utils.internal import get_classes_in_module
 
@@ -44,11 +43,11 @@ ocm_classes = get_classes_in_module(ocm)
 oem_classes = get_classes_in_module(oem)
 osm_classes = get_classes_in_module(osm)
 
-ObeliskControlMsg = TypeVar("ObeliskControlMsg", bound=_create_union_type(ocm_classes))  # type: ignore
-ObeliskEstimatorMsg = TypeVar("ObeliskEstimatorMsg", bound=_create_union_type(oem_classes))  # type: ignore
-ObeliskSensorMsg = TypeVar("ObeliskSensorMsg", bound=_create_union_type(osm_classes))  # type: ignore
-ObeliskMsg = TypeVar("ObeliskMsg", bound=_create_union_type(ocm_classes + oem_classes + osm_classes))  # type: ignore
-ObeliskAllowedMsg = TypeVar(
-    "ObeliskAllowedMsg",
-    bound=_create_union_type(ocm_classes + oem_classes + osm_classes + [ParameterEvent]),  # type: ignore
-)  # [NOTE] ParameterEvent is a special case - all nodes have a ParameterEvent publisher in ROS2
+# ObeliskControlMsg = TypeVar("ObeliskControlMsg", bound=_create_union_type(ocm_classes))  # type: ignore
+# ObeliskEstimatorMsg = TypeVar("ObeliskEstimatorMsg", bound=_create_union_type(oem_classes))  # type: ignore
+# ObeliskSensorMsg = TypeVar("ObeliskSensorMsg", bound=_create_union_type(osm_classes))  # type: ignore
+# ObeliskMsg = TypeVar("ObeliskMsg", bound=_create_union_type(ocm_classes + oem_classes + osm_classes))  # type: ignore
+# ObeliskAllowedMsg = TypeVar(
+#     "ObeliskAllowedMsg",
+#     bound=_create_union_type(ocm_classes + oem_classes + osm_classes + [ParameterEvent]),  # type: ignore
+# )  # [NOTE] ParameterEvent is a special case - all nodes have a ParameterEvent publisher in ROS2

--- a/obelisk/python/obelisk_py/core/robot.py
+++ b/obelisk/python/obelisk_py/core/robot.py
@@ -6,7 +6,6 @@ import obelisk_sensor_msgs.msg as osm
 from rclpy.lifecycle.node import LifecycleState, TransitionCallbackReturn
 
 from obelisk_py.core.node import ObeliskNode
-from obelisk_py.core.obelisk_typing import ObeliskControlMsg
 
 
 class ObeliskRobot(ABC, ObeliskNode):
@@ -28,7 +27,7 @@ class ObeliskRobot(ABC, ObeliskNode):
         )
 
     @abstractmethod
-    def apply_control(self, control_msg: ObeliskControlMsg) -> None:
+    def apply_control(self, control_msg) -> None:
         """Apply the control message to the robot.
 
         Code interfacing with the hardware should be implemented here.


### PR DESCRIPTION
Removing the obelisk message requirements in python. Any message will be allowed to be sent/received.