### PR TITLE
Mujoco sim upgrades

### DIFF
--- a/docs/source/development.md
+++ b/docs/source/development.md
@@ -52,16 +52,11 @@ While in the `pixi` shell and/or Docker container, all changes made in the repos
 ## Building and Running the ROS Stack
 All of the following commands should be run from within the `devcontainer` and within the `dev` pixi virtual environment (which can be entered by running `pixi shell -e dev`).
 
-Build all the messages:
+You can build eveerything with the terminal command:
 ```
-pixi run messages-build
+obk-build
 ```
-
-Build all the ROS packages (including the messages):
-```
-pixi run ros-build
-```
-***Note (as of 9/10/2024): if you have never built the workspace before, you will be required to build the messages first before running `ros-build`. This is because the messages are a dependency for the `ObeliskCpp` library and thus must be built first so they can be used. After you have built the ros workspace once, all future updates only require a `ros-build` command.***
+this will also be sure to build everything in the correct order.
 
 In a seperate terminal, we can run a ROS stack with:
 ```

--- a/docs/source/obelisk_terminal_aliases.md
+++ b/docs/source/obelisk_terminal_aliases.md
@@ -12,6 +12,19 @@ Example:
 obk-launch config_file_path=example.yaml device_name=onboard auto_start=True
 ```
 
+## `obk-build`
+Builds Obelisk.
+Usage:
+```
+obk-build
+```
+
+## `obk-clean`
+Cleans the Obelisk build folders. If the build is failing unexpectedly, it can be useful to run this command and try again.
+```
+obk-clean
+```
+
 ## State Transitions
 ### `obk-configure`
 Configure all Obelisk nodes.

--- a/docs/source/using_obelisk.rst
+++ b/docs/source/using_obelisk.rst
@@ -311,27 +311,20 @@ Obelisk nodes can be easily configured via a Obelisk configuration (yaml) file. 
         # callback_groups:
         publishers:
           - ros_parameter: pub_ctrl_setting
-            # key: pub1
             topic: /obelisk/dummy/ctrl
             msg_type: PositionSetpoint
             history_depth: 10
             callback_group: None
-            non_obelisk: False
         subscribers:
           - ros_parameter: sub_est_setting
-            # key: sub1
             topic: /obelisk/dummy/est
             msg_type: EstimatedState
             history_depth: 10
-            # callback_key: sub_callback1
             callback_group: None
-            non_obelisk: False
         timers:
           - ros_parameter: timer_ctrl_setting
-            # key: timer1
             timer_period_sec: 0.001
             callback_group: None
-            # callback_key: timer_callback1
     estimation:
       - pkg: obelisk_estimation_cpp
         executable: jointencoders_passthrough_estimator
@@ -339,54 +332,58 @@ Obelisk nodes can be easily configured via a Obelisk configuration (yaml) file. 
         publishers:
           - ros_parameter: pub_est_setting
             # key: pub1
-            topic: /obelisk/dummy/est
             msg_type: EstimatedState
             history_depth: 10
             callback_group: None
-            non_obelisk: False
         subscribers:
           - ros_parameter: sub_sensor_setting
-            # key: sub1
             topic: /obelisk/dummy/sensor
             msg_type: JointEncoders
             history_depth: 10
-            # callback_key: sub_callback1
             callback_group: None
-            non_obelisk: False
         timers:
           - ros_parameter: timer_est_setting
-            # key: timer1
             timer_period_sec: 0.001
             callback_group: None
-            # callback_key: timer_callback1
     # sensing:
     robot:
       - is_simulated: True
         pkg: obelisk_sim_cpp
         executable: obelisk_mujoco_robot
+        params:
+          ic_keyframe: ic
         # callback_groups:
         # publishers:
         subscribers:
           - ros_parameter: sub_ctrl_setting
-            # key: sub1
             topic: /obelisk/dummy/ctrl
             msg_type: PositionSetpoint
             history_depth: 10
-            # callback_key: sub_callback1
             callback_group: None
-            non_obelisk: False
         sim:
           - ros_parameter: mujoco_setting
             model_xml_path: dummy/dummy.xml
-            n_u: 1
-            time_step: 0.002
             num_steps_per_viz: 5
             sensor_settings:
-            - topic: /obelisk/dummy/sensor
+            - topic: /obelisk/dummy/joint_encoders
               dt: 0.001
-              sensor_type: jointpos
+              msg_type: ObkJointEncoders
               sensor_names:
-              - sensor_joint1
+                joint_pos: jointpos
+                joint_vel: jointvel
+            - topic: /obelisk/dummy/imu
+              dt: 0.002
+              msg_type: ObkImu
+              sensor_names:
+                tip_acc_sensor: accelerometer
+                tip_gyro_sensor: gyro
+                tip_frame_sensor: framequat
+            - topic: /obelisk/dummy/framepose
+              dt: 0.002
+              msg_type: ObkFramePose
+              sensor_names:
+                tip_pos_sensor: framepos
+                tip_orientation_sensor: framequat
 
 
 Breaking down the configuration file
@@ -412,14 +409,12 @@ First we give the name of this configuration (``dummy``), and which device this 
         key: "asdf"
         history_depth: 10
         callback_group: None
-        non_obelisk: False
     subscribers:
       - ros_parameter: sub_est_setting
         topic: /obelisk/dummy/est
         msg_type: EstimatedState
         history_depth: 10
         callback_group: None
-        non_obelisk: False
     timers:
       - ros_parameter: timer_ctrl_setting
         timer_period_sec: 0.001
@@ -436,7 +431,6 @@ Now we need to configure all of the Components in this node. Publishers and subs
 - ``key`` gives the string key associated with the component if not already specified in the code implementation. **Note this is only ever used in the Python implementation. In C++, the key must be specified during component declaration time.**
 - ``history_depth`` (optional) gives the number of messages to hold in the queue before deleting additional messages. If this not set we the use the default value of 10.
 - ``callback_group`` (optional) gives the string name of the callback group to use. The callback groups can be configured within this configuration file. If no value is specified, then the node's default callback group is used.
-- ``non_obelisk`` (optional) determine whether this node can publish non-Obelisk messages. **Note if this is set to true, then this may cause problems with the interfaces, so only use if you are sure this is what you need.** If no value is specified, then the default value of `False` is used.
 
 Timers have the following options.
 
@@ -457,15 +451,12 @@ This is repeated for every non-system node in the block diagram, which in this c
           msg_type: EstimatedState
           history_depth: 10
           callback_group: None
-          non_obelisk: False
       subscribers:
         - ros_parameter: sub_sensor_setting
-          # key: sub1
           topic: /obelisk/dummy/sensor
           msg_type: JointEncoders
           history_depth: 10
           callback_group: None
-          non_obelisk: False
       timers:
         - ros_parameter: timer_est_setting
           timer_period_sec: 0.001
@@ -480,51 +471,65 @@ Lastly, we need to configure the ``robot`` (aka, the system).
     is_simulated: True
     pkg: obelisk_sim_py
     executable: obelisk_mujoco_robot
+    params:
+      ic_keyframe: ic
     # callback_groups:
     # publishers:
     subscribers:
       - ros_parameter: sub_ctrl_setting
-        # key: sub1
         topic: /obelisk/dummy/ctrl
         msg_type: PositionSetpoint
         history_depth: 10
         callback_group: None
-        non_obelisk: False
     sim:
       - ros_parameter: mujoco_setting
         model_xml_path: dummy/dummy.xml
-        n_u: 1
-        time_step: 0.002
         num_steps_per_viz: 5
         sensor_settings:
-        - topic: /obelisk/dummy/sensor
+        - topic: /obelisk/dummy/joint_encoders
           dt: 0.001
-          sensor_type: jointpos
+          msg_type: ObkJointEncoders
           sensor_names:
-          - sensor_joint1
+            joint_pos: jointpos
+            joint_vel: jointvel
+        - topic: /obelisk/dummy/imu
+          dt: 0.002
+          msg_type: ObkImu
+          sensor_names:
+            tip_acc_sensor: accelerometer
+            tip_gyro_sensor: gyro
+            tip_frame_sensor: framequat
+        - topic: /obelisk/dummy/framepose
+          dt: 0.002
+          msg_type: ObkFramePose
+          sensor_names:
+            tip_pos_sensor: framepos
+            tip_orientation_sensor: framequat
 
 
 ``is_simulated`` marks if we are running on hardware or in simulation. ``pkg`` and ``executable`` are as before.
+``ic_keyframe`` (optional) in the params section tells the simulation which keyframe to use for an initial condition.
 
 Now, we must configure the Components of the node, which in this example is just a subscriber. These Components have all the same options as the non-system Components given above.
 
 Lastly, since this is a simulation, we must provide the simulator with all relevant information. Here, we are using the Mujoco simulation interface. The new settings here are:
 
-- ``n_u`` gives the number of control inputs (i.e., the number of scalars)
-- ``time_step`` (optional) gives the length of a simulation time step. If no value is provided, the default value of 0.002 seconds will be used.
 - ``num_steps_per_viz`` (optional) gives the number of steps to use between simulation rendering. If no value is provided, the default value of 8 steps will be used.
 
 ``sensor_settings`` is how we can specify what sensors our robot has. Within ``sensor_settings`` we have the following new options:
 
+- ``msg_type`` gives the ROS message type associated with the given group of sensors.
 - ``dt`` gives the sensor publishing period in seconds.
-- ``sensor_type`` gives the Mujoco sensor type. Each sensor type corresponds to a specific Obelisk message type. **Note that the Mujoco XML must have all the sensors listed in the Obelisk configuration file, if you request a sensor here that is not available in Mujoco, there will be an error.** All supported Mujoco sensors and corresponding Obelisk messages are listed below.
+- Each element under ``sensor_names`` follows ``sensor_name: sensor_type`` **Note that the Mujoco XML must have all the sensors listed in the Obelisk configuration file, if you request a sensor here that is not available in Mujoco, there will be an error.** All supported Mujoco sensors and corresponding Obelisk messages are listed below.
 
-================== ====================
-Mujoco sensor type Obelisk Message Type
-================== ====================
- ``jointpos``        ``JointEncoders``
-================== ====================
+=============================================== ====================
+Mujoco sensor type                              Obelisk Message Type
+=============================================== ====================
+``jointpos`` and ``jointvel``                   ``ObkJointEncoders``
+``accelerometer``, ``gyro``, and ``framequat``  ``ObkImu``
+``framepos`` and ``framequat``                  ``ObkFramePose``
+=============================================== ====================
 
-- ``sensor_names`` gives the names of the sensors to query, as given in the Mujoco XML.
+You may have multiple of the same type of sensor in the yaml.
 
 Thats it! Now we have configured our Obelisk nodes.

--- a/docs/source/using_obelisk.rst
+++ b/docs/source/using_obelisk.rst
@@ -331,7 +331,7 @@ Obelisk nodes can be easily configured via a Obelisk configuration (yaml) file. 
         # callback_groups:
         publishers:
           - ros_parameter: pub_est_setting
-            # key: pub1
+            topic: /obelisk/dummy/est
             msg_type: EstimatedState
             history_depth: 10
             callback_group: None

--- a/docs/source/using_obelisk.rst
+++ b/docs/source/using_obelisk.rst
@@ -384,6 +384,12 @@ Obelisk nodes can be easily configured via a Obelisk configuration (yaml) file. 
               sensor_names:
                 tip_pos_sensor: framepos
                 tip_orientation_sensor: framequat
+            viz_geoms:
+              dt: 1.0
+              dummy_box: box
+              dummy_box_2: box
+              dummy_sphere: sphere
+
 
 
 Breaking down the configuration file
@@ -505,7 +511,11 @@ Lastly, we need to configure the ``robot`` (aka, the system).
           sensor_names:
             tip_pos_sensor: framepos
             tip_orientation_sensor: framequat
-
+          viz_geoms:
+            dt: 1.0
+            dummy_box: box
+            dummy_box_2: box
+            dummy_sphere: sphere
 
 ``is_simulated`` marks if we are running on hardware or in simulation. ``pkg`` and ``executable`` are as before.
 ``ic_keyframe`` (optional) in the params section tells the simulation which keyframe to use for an initial condition.
@@ -531,5 +541,7 @@ Mujoco sensor type                              Obelisk Message Type
 =============================================== ====================
 
 You may have multiple of the same type of sensor in the yaml.
+
+- ``viz_geoms`` (optional) gives a list of visualization geometries that you want the simulation node to publish. The node will read the state of these geoms from the simulator and publish them so an external visualizer can see them. This is designed mostly for visualizing the environment, not the robot.
 
 Thats it! Now we have configured our Obelisk nodes.

--- a/obelisk/cpp/obelisk_cpp/CMakeLists.txt
+++ b/obelisk/cpp/obelisk_cpp/CMakeLists.txt
@@ -16,6 +16,9 @@ find_package(obelisk_sensor_msgs REQUIRED)
 find_package(obelisk_estimator_msgs REQUIRED)
 find_package(obelisk_std_msgs REQUIRED)
 
+# --------- Viz Messages --------- #
+find_package(visualization_msgs REQUIRED)
+
 # ------- Mujoco ------- #
 include(FetchContent)
 set(MUJOCO_VERSION "3.1.6" CACHE STRING "mujoco version")
@@ -67,4 +70,5 @@ ament_target_dependencies(ObkCore INTERFACE
   obelisk_control_msgs
   obelisk_estimator_msgs
   obelisk_sensor_msgs
+  visualization_msgs
   std_msgs)

--- a/obelisk/cpp/obelisk_cpp/include/obelisk_mujoco_sim_robot.h
+++ b/obelisk/cpp/obelisk_cpp/include/obelisk_mujoco_sim_robot.h
@@ -7,6 +7,8 @@
 #include <GLFW/glfw3.h>
 #include <mujoco/mujoco.h>
 
+#include <visualization_msgs/msg/marker_array.hpp>
+
 #include "ament_index_cpp/get_package_share_directory.hpp"
 
 #include "obelisk_sensor_msgs/msg/obk_joint_encoders.hpp"
@@ -15,7 +17,8 @@
 namespace obelisk {
     template <typename ControlMessageT> class ObeliskMujocoRobot : public ObeliskSimRobot<ControlMessageT> {
       public:
-        explicit ObeliskMujocoRobot(const std::string& name) : ObeliskSimRobot<ControlMessageT>(name) {
+        explicit ObeliskMujocoRobot(const std::string& name)
+            : ObeliskSimRobot<ControlMessageT>(name), viz_key_("viz_geom_pub") {
             this->template declare_parameter<std::string>("mujoco_setting", "");
             this->template declare_parameter<std::string>(
                 "ic_keyframe",
@@ -64,6 +67,12 @@ namespace obelisk {
             configuration_complete_ = true;
 
             ParseSensorString(mujoco_config_map.at("sensor_settings"));
+
+            try {
+                ParseVizString(mujoco_config_map.at("viz_geoms"));
+            } catch (const std::exception& e) {
+                RCLCPP_INFO_STREAM(this->get_logger(), "No geoms to visualize in the simulator.");
+            }
 
             return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
         }
@@ -555,6 +564,176 @@ namespace obelisk {
         }
 
         /**
+         * @brief Parse the settings for visualizing geometries from the mujoco scene.
+         */
+        void ParseVizString(std::string viz_settings) {
+            // TODO: We should probably make the yaml entry a normal list, but with the way config strings are done that
+            // will be a huge pain So in the future we should adjust this. This is because I don't actually need the
+            // user to provide the geom type.
+
+            // Remove {} and []
+            viz_settings.erase(std::remove(viz_settings.begin(), viz_settings.end(), '{'), viz_settings.end());
+            viz_settings.erase(std::remove(viz_settings.begin(), viz_settings.end(), '}'), viz_settings.end());
+            viz_settings.erase(std::remove(viz_settings.begin(), viz_settings.end(), '['), viz_settings.end());
+            viz_settings.erase(std::remove(viz_settings.begin(), viz_settings.end(), ']'), viz_settings.end());
+
+            // Wait for mujoco setup to complete
+            while (!mujoco_setup_) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(2));
+            }
+
+            // Extract the geom id's for publishing
+            // Create a new map between the names and their string values
+            const std::string setting_delim = "|";
+            const std::string val_delim     = ":";
+            std::map<std::string, std::string> setting_map;
+
+            size_t val_idx;
+            while (!viz_settings.empty()) {
+                val_idx = viz_settings.find(setting_delim);
+                if (val_idx == std::string::npos) {
+                    val_idx = viz_settings.length();
+                }
+
+                size_t setting_idx = viz_settings.find(val_delim);
+                if (setting_idx == std::string::npos) {
+                    throw std::runtime_error("Invalid viz setting string!");
+                }
+
+                std::string setting = viz_settings.substr(0, setting_idx);
+                std::string val     = viz_settings.substr(setting_idx + 1, val_idx - (setting_idx + 1));
+                setting_map.emplace(setting, val);
+                viz_settings.erase(0, val_idx + val_delim.length());
+            }
+
+            // The dt for the timer
+            double dt = -1;
+            try {
+                dt = std::stod(setting_map.at("dt"));
+                if (dt <= 0) {
+                    throw std::runtime_error("Invalid dt. Must be > 0.");
+                }
+            } catch (const std::exception& e) {
+                throw std::runtime_error("No dt provided for the viz publisher!");
+            }
+
+            for (const auto& [key, value] : setting_map) {
+                if (key != "dt") {
+                    // Find the mujoco geom with that name
+                    const int geom_id = mj_name2id(model_, mjtObj::mjOBJ_GEOM, key.c_str());
+                    if (geom_id == -1) {
+                        RCLCPP_ERROR_STREAM(this->get_logger(), "Geom " << key << " not found in the model! Skipping!");
+                    } else {
+                        // TODO: Can easily add elipsoids in
+                        if (model_->geom_type[geom_id] != mjtGeom::mjGEOM_BOX &&
+                            model_->geom_type[geom_id] != mjtGeom::mjGEOM_SPHERE &&
+                            model_->geom_type[geom_id] != mjtGeom::mjGEOM_CYLINDER) {
+                            RCLCPP_ERROR_STREAM(this->get_logger(),
+                                                "Geom type not supported! Only support Box, Sphere, and Cylinder.");
+                        } else {
+                            viz_geoms_.emplace_back(geom_id);
+                        }
+                    }
+                }
+            }
+
+            if (viz_geoms_.size() > 0) {
+                RCLCPP_INFO_STREAM(this->get_logger(), "Publishing the given mujoco geoms.");
+                // For now hard code the topic
+                auto pub = ObeliskNode::create_publisher<visualization_msgs::msg::MarkerArray>(
+                    "obelisk/sim/mujoco_scene_viz", 10);
+                this->publishers_[viz_key_] =
+                    std::make_shared<internal::ObeliskPublisher<visualization_msgs::msg::MarkerArray>>(pub);
+
+                // Add the timer to the list
+                this->timers_[viz_key_] =
+                    this->create_wall_timer(std::chrono::milliseconds(static_cast<uint>(1e3 * dt)),
+                                            std::bind(&ObeliskMujocoRobot::VizTimerCallback, this), callback_group_);
+            }
+        }
+
+        void VizTimerCallback() {
+            std::vector<std::array<double, 3>> positions(viz_geoms_.size());
+            std::vector<std::array<double, 9>> rotmats(viz_geoms_.size());
+            std::vector<std::array<double, 3>> sizes(viz_geoms_.size());
+            std::vector<int> geom_types(viz_geoms_.size());
+
+            {
+                // Grab the mutex on the model and data
+                std::lock_guard<std::mutex> lock(sensor_data_mut_);
+
+                // Get the position and orientation of the geoms
+                for (size_t i = 0; i < viz_geoms_.size(); i++) {
+                    geom_types[i] = model_->geom_type[viz_geoms_[i]];
+
+                    for (int j = 0; j < 3; j++) {
+                        positions[i][j] = data_->geom_xpos[3 * viz_geoms_[i] + j];
+                        sizes[i][j]     = model_->geom_size[3 * viz_geoms_[i] + j];
+                    }
+
+                    for (int j = 0; j < 9; j++) {
+                        rotmats[i][j] = data_->geom_xmat[9 * viz_geoms_[i] + j];
+                    }
+                }
+            }
+
+            // Format for the display marker
+            visualization_msgs::msg::MarkerArray msg;
+            msg.markers.resize(viz_geoms_.size());
+
+            for (size_t i = 0; i < msg.markers.size(); i++) {
+                msg.markers[i].header.frame_id = "world";
+                msg.markers[i].header.stamp    = this->now();
+
+                msg.markers[i].ns     = "mujoco_scene_viz";
+                msg.markers[i].id     = i;
+                msg.markers[i].action = visualization_msgs::msg::Marker::MODIFY;
+
+                msg.markers[i].pose.position.x = positions[i][0];
+                msg.markers[i].pose.position.y = positions[i][1];
+                msg.markers[i].pose.position.z = positions[i][2];
+
+                // Convert the rotmats to quats
+                mjtNum quat[4];
+                mjtNum* mat = rotmats[i].data();
+                mju_mat2Quat(quat, mat);
+
+                msg.markers[i].pose.orientation.x = -quat[1];
+                msg.markers[i].pose.orientation.y = -quat[2];
+                msg.markers[i].pose.orientation.z = -quat[3];
+                msg.markers[i].pose.orientation.w = -quat[0];
+
+                msg.markers[i].color.a = 1.0;
+                msg.markers[i].color.r = 0.69;
+                msg.markers[i].color.g = 0.541;
+                msg.markers[i].color.b = 0.094;
+
+                if (geom_types[i] == mjtGeom::mjGEOM_BOX) {
+                    msg.markers[i].scale.x = sizes[i][0] * 2;
+                    msg.markers[i].scale.y = sizes[i][1] * 2;
+                    msg.markers[i].scale.z = sizes[i][2] * 2;
+
+                    msg.markers[i].type = visualization_msgs::msg::Marker::CUBE;
+                } else if (geom_types[i] == mjtGeom::mjGEOM_SPHERE) {
+                    msg.markers[i].scale.x = sizes[i][0] * 2;
+                    msg.markers[i].scale.y = sizes[i][0] * 2;
+                    msg.markers[i].scale.z = sizes[i][0] * 2;
+
+                    msg.markers[i].type = visualization_msgs::msg::Marker::SPHERE;
+                } else if (geom_types[i] == mjtGeom::mjGEOM_CYLINDER) {
+                    msg.markers[i].scale.x = sizes[i][0] * 2;
+                    msg.markers[i].scale.y = sizes[i][0] * 2;
+                    msg.markers[i].scale.z = sizes[i][1] * 2;
+
+                    msg.markers[i].type = visualization_msgs::msg::Marker::CYLINDER;
+                }
+            }
+
+            // Publish
+            this->template GetPublisher<visualization_msgs::msg::MarkerArray>(viz_key_)->publish(msg);
+        }
+
+        /**
          * @brief Create all the sensor message callbacks.
          * @param MessageT the templated message type
          * @param sensor_names a list of mujoco sensors associated with this message
@@ -965,6 +1144,12 @@ namespace obelisk {
         std::filesystem::path xml_path_;
         float time_step_;
         int num_steps_per_viz_;
+
+        // Key for viz publishing
+        std::string viz_key_;
+
+        // Geom id's for viz
+        std::vector<int> viz_geoms_;
 
         // Shared data between the main thread and the sim thread
         std::vector<double> shared_data_;

--- a/obelisk_ws/src/obelisk_ros/config/dummy_cpp.yaml
+++ b/obelisk_ws/src/obelisk_ros/config/dummy_cpp.yaml
@@ -81,8 +81,6 @@ onboard:
           non_obelisk: False
       sim:
         - ros_parameter: mujoco_setting
-          n_u: 1
-          time_step: 0.002
           num_steps_per_viz: 5
           robot_pkg: dummy_bot
           model_xml_path: dummy.xml

--- a/obelisk_ws/src/obelisk_ros/config/dummy_cpp_viz.yaml
+++ b/obelisk_ws/src/obelisk_ros/config/dummy_cpp_viz.yaml
@@ -96,6 +96,12 @@ onboard:
             sensor_names:
               tip_pos_sensor: framepos
               tip_orientation_sensor: framequat
+          viz_geoms:
+            dt: 1.0
+            dummy_box: box
+            dummy_box_2: box
+            dummy_sphere: sphere
+
   viz:
     on: True
     viz_tool: rviz

--- a/obelisk_ws/src/obelisk_ros/config/dummy_cpp_viz.yaml
+++ b/obelisk_ws/src/obelisk_ros/config/dummy_cpp_viz.yaml
@@ -73,8 +73,6 @@ onboard:
           non_obelisk: False
       sim:
         - ros_parameter: mujoco_setting
-          n_u: 1
-          time_step: 0.002
           num_steps_per_viz: 5
           robot_pkg: dummy_bot
           model_xml_path: dummy.xml

--- a/obelisk_ws/src/obelisk_ros/config/dummy_cpp_zed.yaml
+++ b/obelisk_ws/src/obelisk_ros/config/dummy_cpp_zed.yaml
@@ -81,8 +81,6 @@ onboard:
           non_obelisk: False
       sim:
         - ros_parameter: mujoco_setting
-          n_u: 1
-          time_step: 0.002
           num_steps_per_viz: 5
           robot_pkg: dummy_bot
           model_xml_path: dummy.xml

--- a/obelisk_ws/src/robots/dummy_bot/mujoco/dummy.xml
+++ b/obelisk_ws/src/robots/dummy_bot/mujoco/dummy.xml
@@ -53,6 +53,6 @@
 
     <keyframe>
         <key name="other" qpos="-1" ctrl="-1" time="1"/>
-        <key name="ic" qpos="1" ctrl="1" time="0" />
+        <key name="ic" qpos="1" ctrl="1" time="2000" />
     </keyframe>
 </mujoco>

--- a/obelisk_ws/src/robots/dummy_bot/mujoco/dummy.xml
+++ b/obelisk_ws/src/robots/dummy_bot/mujoco/dummy.xml
@@ -19,7 +19,7 @@
         <light name="light" pos="0 0 3" dir="0 0 -1" diffuse="1 1 1" specular="0.3 0.3 0.3"/>
 
         <!-- Robot -->
-        <body name="link0" pos="0 0 0">
+        <body name="link0" pos="0 0 0" quat="-0.707 0 0 0.707">
             <geom type="cylinder" fromto="0 0 0 0 0 1" size="0.05"/>
             <body name="link1" pos="0 0 1">
                 <geom type="cylinder" fromto="0 0 0 0 0 1" size="0.05"/>
@@ -27,6 +27,13 @@
                 <site name="imu_site" pos="0 0 1" euler="0 0 0" size="0.001"/>
                 <site name="tip" pos="0 0 1" euler="0 0 0" size="0.001"/>
             </body>
+        </body>
+
+        <!-- Other Objects -->
+        <body>
+            <geom name="dummy_box_2" type="box" pos="2 1 0.5" quat="0.577 0.577 0 0.577" size="0.5 0.25 0.25"/>
+            <geom name="dummy_box" type="box" pos="-1 1 0.5" size="0.5 0.25 0.25"/>
+            <geom name="dummy_sphere" type="sphere" pos="-2 2 2.5" size="0.25"/>
         </body>
     </worldbody>
 


### PR DESCRIPTION
Updated some features in the Mujoco simulation:
- Removed the need to specify `nu` in the yaml, instead we now read that from the Mujoco model. This was annoying because if you forgot to update the yaml it was hard to figure out what the issue was.
- Removed the need to specify the sim timestep in the yaml, instead we now read that from the Mujoco model. In the future we can add back the option to overwrite the Mujoco time step with what the user puts in the yaml, but for now that seems unnecessary.

Updated the docs to be more accurate.