### PR TITLE
Unitree debug

### DIFF
--- a/obelisk/cpp/zoo/hardware/robots/unitree/g1_interface.h
+++ b/obelisk/cpp/zoo/hardware/robots/unitree/g1_interface.h
@@ -260,7 +260,7 @@ namespace obelisk {
             this->GetPublisher<obelisk_sensor_msgs::msg::ObkImu>(pub_imu_state_key_)->publish(imu_state);
 
             // Log motor data if logging is enabled
-            if (logging_) {
+            if (logging_ && this->log_count_ % 1000 == 0) { // Log at 1 Hz assuming 1kHz low state rate
                 LogMotorData(low_state);
             }
 
@@ -420,6 +420,8 @@ namespace obelisk {
                                << "," << motor.motorstate();
             }
             motor_data_log_ << "\n";
+
+            this->log_count_++;
         }
 
     private:

--- a/obelisk/cpp/zoo/hardware/robots/unitree/unitree_interface.h
+++ b/obelisk/cpp/zoo/hardware/robots/unitree/unitree_interface.h
@@ -65,6 +65,8 @@ namespace obelisk {
                 std::filesystem::create_directories(session_dir);
                 log_dir_path_ = session_dir.string();
                 RCLCPP_INFO_STREAM(this->get_logger(), "Created logging directory: " << session_dir);
+
+                log_count_ = 0;
             }
 
             // Register Execution FSM Subscriber
@@ -311,6 +313,7 @@ namespace obelisk {
         // Logging
         bool logging_;
         std::string log_dir_path_;
+        long log_count_;
     
     private:
     };

--- a/obelisk/cpp/zoo/hardware/robots/unitree/unitree_interface.h
+++ b/obelisk/cpp/zoo/hardware/robots/unitree/unitree_interface.h
@@ -6,6 +6,10 @@
 #include "obelisk_control_msgs/msg/pd_feed_forward.h"
 #include "obelisk_control_msgs/msg/execution_fsm.hpp"
 #include "obelisk_control_msgs/msg/velocity_command.hpp"
+#include <filesystem>
+#include <chrono>
+#include <iomanip>
+#include <sstream>
 
 
 // DDS
@@ -43,6 +47,25 @@ namespace obelisk {
             // Additional Publishers
             this->RegisterObkPublisher<obelisk_sensor_msgs::msg::ObkJointEncoders>("pub_sensor_setting", pub_joint_state_key_);
             this->RegisterObkPublisher<obelisk_sensor_msgs::msg::ObkImu>("pub_imu_setting", pub_imu_state_key_);
+
+            // Optional low level logging
+            this->declare_parameter<bool>("logging", false);
+            logging_ = this->get_parameter("logging").as_bool();
+
+            // Create logging directory if logging is enabled
+            if (logging_) {
+                auto now = std::chrono::system_clock::now();
+                auto time_t = std::chrono::system_clock::to_time_t(now);
+                std::stringstream ss;
+                ss << std::put_time(std::localtime(&time_t), "%Y-%m-%d_%H-%M-%S");
+                
+                std::filesystem::path unitree_logs_dir = "unitree_logs";
+                std::filesystem::path session_dir = unitree_logs_dir / ss.str();
+                
+                std::filesystem::create_directories(session_dir);
+                log_dir_path_ = session_dir.string();
+                RCLCPP_INFO_STREAM(this->get_logger(), "Created logging directory: " << session_dir);
+            }
 
             // Register Execution FSM Subscriber
             this->RegisterObkSubscription<unitree_fsm_msg>(
@@ -284,6 +307,10 @@ namespace obelisk {
         const std::string sub_high_level_ctrl_key_ = "sub_high_level_ctrl_key";
         const std::string pub_joint_state_key_ = "joint_state_pub";
         const std::string pub_imu_state_key_ = "imu_state_pub";
+
+        // Logging
+        bool logging_;
+        std::string log_dir_path_;
     
     private:
     };


### PR DESCRIPTION
Adds low-level unitree motor data logging to a csv file.

Creates a `unitree_logs` directory and sub-directories for each run that are timestamped for each run.

You can toggle the ability to log by setting the `logging` flag in the config.