### PR TITLE
Name launched nodes from the config entry's name field

### DIFF
--- a/obelisk/python/obelisk_py/core/utils/launch_utils.py
+++ b/obelisk/python/obelisk_py/core/utils/launch_utils.py
@@ -400,10 +400,19 @@ def get_launch_actions_from_node_settings(
         package = node_settings["pkg"]
         executable = node_settings["executable"]
         parameters_dict = get_parameters_dict(node_settings)
+        # Name the ROS node after the entry's config `name` when it has a real one
+        # (the same key the include keyed-merge uses), e.g. `obelisk_control_graph_planner`.
+        # The reserved UNKNOWN<n> placeholder assigned to anonymous entries is not a real
+        # name, so those entries keep the positional `obelisk_{type}_{index}` fallback.
+        cfg_name = node_settings.get("name")
+        if isinstance(cfg_name, str) and cfg_name and not _ANON_RE.match(cfg_name):
+            node_name = f"obelisk_{node_type}_{cfg_name}"
+        else:
+            node_name = f"obelisk_{node_type}" if suffix is None else f"obelisk_{node_type}_{suffix}"
         launch_actions = []
         component_node = LifecycleNode(
             namespace="",
-            name=f"obelisk_{node_type}" if suffix is None else f"obelisk_{node_type}_{suffix}",
+            name=node_name,
             package=package,
             executable=executable,
             output="both",

--- a/tests/tests_python/tests_core/test_utils/test_launch_utils.py
+++ b/tests/tests_python/tests_core/test_utils/test_launch_utils.py
@@ -543,6 +543,20 @@ def test_get_launch_actions_from_node_settings(
     assert isinstance(launch_actions[0], LifecycleNode)
 
 
+def test_get_launch_actions_node_names(test_global_state_node: LifecycleNode) -> None:
+    """A real config `name` names the ROS node; anonymous/placeholder entries keep the positional fallback."""
+    node_settings = [
+        {"pkg": "p", "executable": "e", "name": "graph_planner"},
+        {"pkg": "p", "executable": "e"},
+        {"pkg": "p", "executable": "e", "name": "UNKNOWN0"},
+    ]
+    launch_actions = get_launch_actions_from_node_settings(node_settings, "control", test_global_state_node)
+    nodes = [a for a in launch_actions if isinstance(a, LifecycleNode)]
+    # the raw constructor name (node_name is only readable after the action executes)
+    names = [n._Node__node_name for n in nodes]
+    assert names == ["obelisk_control_graph_planner", "obelisk_control_1", "obelisk_control_2"]
+
+
 def test_get_launch_actions_from_node_settings_invalid_type(test_global_state_node: LifecycleNode) -> None:
     """An unknown node type asserts."""
     invalid = {


### PR DESCRIPTION
Component nodes were always named obelisk_{type}_{index}, so a stack with several control entries shows up as obelisk_control_0..N on the graph. The config entries already carry a `name:` key (the include keyed-merge identity); use it to name the ROS node too: obelisk_{type}_{name}, e.g. obelisk_control_graph_planner. Entries without a real name (including the reserved UNKNOWN<n> placeholder for anonymous entries) keep the positional fallback, so existing unnamed configs are unaffected.