### PR TITLE
lidar: per-direction occlusion mask (compact rays + dense ObkScan sca…

### DIFF
--- a/obelisk/cpp/obelisk_cpp/include/obelisk_mujoco_sim_robot.h
+++ b/obelisk/cpp/obelisk_cpp/include/obelisk_mujoco_sim_robot.h
@@ -1280,6 +1280,17 @@ namespace obelisk {
                         viz_bucket.reserve(scan_interface_->get_num_rays() / scan_viz_decimation_ + 1);
                     }
 
+                    // When a per-direction mask compacted the ray set, only the unmasked
+                    // rays were cast; the ObkScan must stay DENSE (length dense_num_rays in
+                    // v*nh+h order), so pre-fill with NaN (no-hit) and scatter the cast rays
+                    // back via the dense index. Unmasked path keeps the original push_back.
+                    const bool scan_masked = scan_interface_->is_masked();
+                    if (scan_masked) {
+                        msg.data.assign(scan_interface_->get_dense_num_rays(),
+                                        std::numeric_limits<float>::quiet_NaN());
+                    }
+                    const std::vector<int>& dense_idx = scan_interface_->get_dense_index();
+
                     for (int ii = 0; ii < scan_interface_->get_num_rays(); ++ii) {
                         Eigen::Vector3d ray_origin = starts_w.row(ii).transpose();
                         Eigen::Vector3d direction  = dirs_w.row(ii).transpose();
@@ -1289,7 +1300,10 @@ namespace obelisk {
                         if (dist < 0) {
                             // No hit: publish a NaN sentinel and skip the hit point so we don't
                             // fabricate a point behind the sensor (opposite the ray) for viz.
-                            msg.data.push_back(std::numeric_limits<float>::quiet_NaN());
+                            // (In masked mode the dense array is already NaN-filled -> just skip.)
+                            if (!scan_masked) {
+                                msg.data.push_back(std::numeric_limits<float>::quiet_NaN());
+                            }
                             continue;
                         }
 
@@ -1300,7 +1314,11 @@ namespace obelisk {
                             ray_origin[2] + direction[2] * dist
                         };
                         float ret = scan_interface_->get_return(hit_point, dist);
-                        msg.data.push_back(ret);
+                        if (scan_masked) {
+                            msg.data[dense_idx[ii]] = ret;    // scatter to the dense grid position
+                        } else {
+                            msg.data.push_back(ret);
+                        }
                         if (scan_viz_enabled_ && ii % scan_viz_decimation_ == 0) {
                             viz_bucket.push_back({hit_point[0], hit_point[1], hit_point[2]});
                         }

--- a/obelisk/cpp/obelisk_cpp/lidar/lidar_interface.h
+++ b/obelisk/cpp/obelisk_cpp/lidar/lidar_interface.h
@@ -2,6 +2,11 @@
 
 #include "ray_caster_interface.h"
 
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <vector>
+
 #ifndef M_PI
 #define M_PI 3.14159265358979323846
 #endif
@@ -197,12 +202,81 @@ class LidarInterface : public RayCasterInterface {
         // Apply the same offset rotation to the optical axis
         image_forward_local_ = quat_apply(offset.rot, image_forward_local_);
         image_forward_local_.normalize();
+
+        // Optional per-direction occlusion mask: cast ONLY the unmasked rays (drop
+        // masked rows here so mj_multiRay batches fewer rays), and remember where each
+        // kept ray sits in the dense nv*nh grid so dense consumers (ObkScan) can scatter
+        // the results back with a no-hit sentinel at masked bins.
+        if (pattern["mask"]) {
+            apply_mask(load_mask(pattern["mask"], nv, nh));
+        }
     }
 
+    // ---- masked-scan support (RayCasterInterface overrides) ----
+    int get_dense_num_rays() const override {
+        return masked_ ? dense_num_rays_ : get_num_rays();
+    }
+    bool is_masked() const override { return masked_; }
+    const std::vector<int>& get_dense_index() const override { return dense_index_; }
+
   private:
+    // Read the mask (1 = masked) as a flat nv*nh row-major (v*nh+h) vector. Accepts a
+    // path to a text grid (numpy savetxt: '#'-comment lines, then comma/space-separated
+    // 0/1 rows) or an inline YAML list of 0/1 of length nv*nh.
+    std::vector<char> load_mask(const YAML::Node& node, int nv, int nh) const {
+        const int n = nv * nh;
+        std::vector<char> mask;
+        mask.reserve(n);
+        if (node.IsSequence()) {
+            for (const auto& v : node) mask.push_back(v.as<int>() != 0 ? 1 : 0);
+        } else {
+            const std::string path = node.as<std::string>();
+            std::ifstream f(path);
+            if (!f) throw std::runtime_error("Lidar mask file not found: " + path);
+            std::string line;
+            while (std::getline(f, line)) {
+                if (line.empty() || line[0] == '#') continue;
+                for (char& c : line) if (c == ',') c = ' ';   // accept comma- or space-separated
+                std::istringstream ss(line);
+                int val;
+                while (ss >> val) mask.push_back(val != 0 ? 1 : 0);
+            }
+        }
+        if (static_cast<int>(mask.size()) != n) {
+            throw std::runtime_error("Lidar mask has " + std::to_string(mask.size()) +
+                                     " entries, expected channels*horizontal = " +
+                                     std::to_string(n) + " (v*nh+h order)");
+        }
+        return mask;
+    }
+
+    // Compact ray_starts_local_/ray_directions_local_ to the unmasked rays, building
+    // the compacted->dense index map. get_num_rays() then returns the reduced count.
+    void apply_mask(const std::vector<char>& mask) {
+        const int dense = static_cast<int>(ray_directions_local_.rows());
+        MatrixX3d starts_keep(dense, 3), dirs_keep(dense, 3);
+        dense_index_.clear();
+        dense_index_.reserve(dense);
+        int kept = 0;
+        for (int i = 0; i < dense; ++i) {
+            if (mask[i]) continue;                 // masked -> not cast
+            starts_keep.row(kept) = ray_starts_local_.row(i);
+            dirs_keep.row(kept) = ray_directions_local_.row(i);
+            dense_index_.push_back(i);
+            ++kept;
+        }
+        ray_starts_local_ = starts_keep.topRows(kept);
+        ray_directions_local_ = dirs_keep.topRows(kept);
+        dense_num_rays_ = dense;
+        masked_ = true;
+    }
+
     int nv_ = 0;
     int nh_ = 0;
     Vector3d image_forward_local_ = Vector3d::Zero();
+    bool masked_ = false;
+    int dense_num_rays_ = 0;
+    std::vector<int> dense_index_;   // compacted ray index -> dense (v*nh+h) index
 };
 
 } // namespace obelisk

--- a/obelisk/cpp/obelisk_cpp/lidar/ray_caster_interface.h
+++ b/obelisk/cpp/obelisk_cpp/lidar/ray_caster_interface.h
@@ -9,6 +9,7 @@
 #include <filesystem>
 #include <stdexcept>
 #include <string>
+#include <vector>
 
 namespace obelisk {
 
@@ -77,6 +78,30 @@ class RayCasterInterface {
      * @brief Get number of rays in the pattern
      */
     int get_num_rays() const { return static_cast<int>(ray_starts_local_.rows()); }
+
+    /**
+     * @brief Number of rays in the FULL dense grid (before any mask compaction).
+     *
+     * Without a mask this equals get_num_rays(). With a per-direction occlusion mask
+     * the sensor casts only the unmasked rays (get_num_rays() shrinks), but dense
+     * consumers (e.g. the ObkScan grid, length nv*nh in v*nh+h order) still expect
+     * the full count -- scatter the cast rays back via get_dense_index().
+     */
+    virtual int get_dense_num_rays() const { return get_num_rays(); }
+
+    /**
+     * @brief True if a per-direction mask compacted the ray set (fewer rays cast).
+     */
+    virtual bool is_masked() const { return false; }
+
+    /**
+     * @brief Map from compacted ray index -> dense grid index (v*nh+h). Size ==
+     * get_num_rays(); empty when unmasked (dense == compacted, identity).
+     */
+    virtual const std::vector<int>& get_dense_index() const {
+        static const std::vector<int> kEmpty;
+        return kEmpty;
+    }
 
     /**
      * @brief Get ray starts in local frame (read-only)


### PR DESCRIPTION
…tter)

LidarInterface::setup_rays now accepts an optional `pattern.mask` (path to a 0/1 grid file or inline list, v*nh+h order). Masked rays are dropped from the local ray set so mj_multiRay batches fewer rays; a compacted->dense index map lets the ObkScan publisher scatter results back into the full nv*nh grid with a NaN (no-hit) at masked bins, keeping the dense array index-aligned with the policy. The PointCloud2 path needs no change (compaction => masked bins simply produce no points). Adds base virtuals get_dense_num_rays / is_masked / get_dense_index (default = unmasked identity).

Used by the g1_nav v2 masked head-lidar scan configs (nav_head_lidar*_v2.yml).